### PR TITLE
Update status of antreainstall CR

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,10 +4,12 @@
 package controller
 
 import (
-	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+
 	"github.com/ruicao93/antrea-operator/pkg/controller/sharedinfo"
+	"github.com/ruicao93/antrea-operator/pkg/types"
 	"github.com/ruicao93/antrea-operator/version"
 )
 
@@ -16,7 +18,7 @@ var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, *sha
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager) error {
-	s := statusmanager.New(m.GetClient(), m.GetRESTMapper(), "antrea", version.Version)
+	s := statusmanager.New(m.GetClient(), m.GetRESTMapper(), types.AntreaClusterOperatorName, version.Version)
 	sharedInfo := sharedinfo.New()
 	for _, f := range AddToManagerFuncs {
 		if err := f(m, s, sharedInfo); err != nil {

--- a/pkg/controller/statusmanager/status_manager.go
+++ b/pkg/controller/statusmanager/status_manager.go
@@ -1,0 +1,67 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package statusmanager
+
+import (
+	"context"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
+	operatortypes "github.com/ruicao93/antrea-operator/pkg/types"
+)
+
+var log = logf.Log.WithName("status_manager")
+
+func SetAntreaInstallStatus(client client.Client, conditionType configv1.ClusterStatusConditionType, status configv1.ConditionStatus, t time.Time, reason, message string) {
+	antreaInstall := &operatorv1.AntreaInstall{}
+	err := client.Get(context.TODO(), types.NamespacedName{Namespace: operatortypes.OperatorNameSpace, Name: operatortypes.OperatorConfigName}, antreaInstall)
+	if err != nil {
+		log.Error(err, "failed to get AntreaInstall")
+	}
+	antreaInstall.Status.Conditions = []operatorv1.InstallCondition{
+		{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: metav1.NewTime(t),
+		},
+	}
+	if reason != "" {
+		antreaInstall.Status.Conditions[0].Reason = reason
+	}
+	if message != "" {
+		antreaInstall.Status.Conditions[0].Message = message
+	}
+	if err := client.Status().Update(context.TODO(), antreaInstall); err != nil {
+		log.Error(err, "failed to set AntreaInstall")
+	}
+}
+
+func SetAntreaInstallDegraded(client client.Client, reason, message string) {
+	SetAntreaInstallStatus(client, configv1.OperatorDegraded, configv1.ConditionTrue, time.Now(), reason, message)
+}
+
+func SetAntreaInstallNotDegraded(client client.Client) {
+	SetAntreaInstallStatus(client, configv1.OperatorDegraded, configv1.ConditionFalse, time.Now(), "", "")
+}
+
+func SetDegraded(client client.Client, status *statusmanager.StatusManager, statusLevel statusmanager.StatusLevel, reason, message string) {
+	// Set clusteroperator/antrea status
+	status.SetDegraded(statusLevel, reason, message)
+	// Set AntreaInstall CR status
+	SetAntreaInstallDegraded(client, reason, message)
+}
+
+func SetNotDegraded(client client.Client, status *statusmanager.StatusManager, statusLevel statusmanager.StatusLevel) {
+	// Set clusteroperator/antrea status
+	status.SetNotDegraded(statusLevel)
+	// Set AntreaInstall CR status
+	SetAntreaInstallNotDegraded(client)
+}

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -4,7 +4,8 @@
 package types
 
 const (
-	AntreaImageRenderKey = "AntreaImage"
+	AntreaClusterOperatorName = "antrea"
+	AntreaImageRenderKey      = "AntreaImage"
 
 	AntreaAgentConfigOption    = "antrea-agent.conf"
 	AntreaAgentConfigRenderKey = "AntreaAgentConfig"


### PR DESCRIPTION
This patch:
- Updates antreainstall.status according to the reconciliation result.
- Check configuration spec difference at the beginning of
  config_controller reconciliation logic to avoid infinite update.

Signed-off-by: Rui Cao <rcao@vmware.com>
(cherry picked from ruicao93/antrea-operator)