### PR TITLE
Show version in clusteroperator/antrea status

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -98,6 +98,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup release version
+	if err := os.Setenv("RELEASE_VERSION", version.Version); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")

--- a/manifest/antrea.yml
+++ b/manifest/antrea.yml
@@ -706,6 +706,8 @@ metadata:
     component: antrea-controller
   name: antrea-controller
   namespace: kube-system
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   replicas: 1
   selector:
@@ -834,6 +836,8 @@ metadata:
     component: antrea-agent
   name: antrea-agent
   namespace: kube-system
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
 	"github.com/ruicao93/antrea-operator/pkg/types"
+	"github.com/ruicao93/antrea-operator/version"
 )
 
 func FillConfigs(clusterConfig *configv1.Network, operConfig *operatorv1.AntreaInstall) error {
@@ -223,6 +224,7 @@ func pluginCNIConfDir(conf *ocoperv1.NetworkSpec) string {
 func GenerateRenderData(operatorNetwork *ocoperv1.Network, operConfig *operatorv1.AntreaInstall) (*render.RenderData, error) {
 	renderData := render.MakeRenderData()
 
+	renderData.Data[types.ReleaseVersion] = version.Version
 	renderData.Data[types.AntreaAgentConfigRenderKey] = operConfig.Spec.AntreaAgentConfig
 	renderData.Data[types.AntreaCNIConfigRenderKey] = operConfig.Spec.AntreaCNIConfig
 	renderData.Data[types.AntreaControllerConfigRenderKey] = operConfig.Spec.AntreaControllerConfig

--- a/pkg/controller/config/config_test.go
+++ b/pkg/controller/config/config_test.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
 	operatortypes "github.com/ruicao93/antrea-operator/pkg/types"
+	"github.com/ruicao93/antrea-operator/version"
 )
 
 var mockClusterConfig = configv1.Network{
@@ -134,6 +135,12 @@ func TestRender(t *testing.T) {
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), antreaDeployment)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(antreaDeployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(operatortypes.DefaultAntreaImage))
+			g.Expect(antreaDeployment.Annotations["release.openshift.io/version"]).Should(Equal(version.Version))
+		} else if obj.GetKind() == "DaemonSet" && obj.GetNamespace() == "kube-system" && obj.GetName() == "antrea-agent" {
+			antreaDaemonSet := &appsv1.DaemonSet{}
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), antreaDaemonSet)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(antreaDaemonSet.Annotations["release.openshift.io/version"]).Should(Equal(version.Version))
 		}
 	}
 }

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -6,6 +6,7 @@ package types
 const (
 	AntreaClusterOperatorName = "antrea"
 	AntreaImageRenderKey      = "AntreaImage"
+	ReleaseVersion            = "ReleaseVersion"
 
 	AntreaAgentConfigOption    = "antrea-agent.conf"
 	AntreaAgentConfigRenderKey = "AntreaAgentConfig"


### PR DESCRIPTION
- Add "release.openshift.io/version" annotation in
  antrea-controller deployment and antrea-agent
  daemonset.
- Set value "RELEASE_VERSION" env from code version.
- Set the value of "release.openshift.io/version"
  annotation from code version.

Signed-off-by: Rui Cao <rcao@vmware.com>
(cherry picked from ruicao93/antrea-operator)