### PR TITLE
Github workflows: Don't push bundle image to dockerhub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,3 @@ jobs:
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           docker push antrea/antrea-operator:latest
-          docker push antrea/antrea-operator-bundle:latest


### PR DESCRIPTION
1) There is no real reason for pushing it.
2) Workflows are currently failing as the dockerhub token does
   not have right for pushing antrea-operator-bundle