### PR TITLE
Add verb patch for role antrea-operator

### DIFF
--- a/deploy/kubernetes/role.yaml
+++ b/deploy/kubernetes/role.yaml
@@ -42,7 +42,7 @@ rules:
 # Required by antrea-agent, antrea-controller and antctl
 - apiGroups: [""]
   resources: [nodes]
-  verbs: [get, watch, list]
+  verbs: [get, watch, list, patch]
 - apiGroups: [""]
   resources: [pods, endpoints]
   verbs: [get, watch, list, delete]

--- a/deploy/openshift/role.yaml
+++ b/deploy/openshift/role.yaml
@@ -42,7 +42,7 @@ rules:
 # Required by antrea-agent, antrea-controller and antctl
 - apiGroups: [""]
   resources: [nodes]
-  verbs: [get, watch, list]
+  verbs: [get, watch, list, patch]
 - apiGroups: [""]
   resources: [pods, endpoints]
   verbs: [get, watch, list, delete]


### PR DESCRIPTION
The permission of 'patch' for role antrea-operator is required in
the process of deploying Antrea operator.