### PR TITLE
Build Antrea UBI image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ docker-build:
 	docker build -f build/Dockerfile . -t ${IMG}
 	docker tag ${IMG} antrea/antrea-operator
 
+antrea-build:
+	cd build/antrea && ./build_ubi.sh --tag ${TAG} --antrea-version ${VERSION}
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ To build antrea operator binary. Run the following command.
 make bin
 ```
 
+To build Antrea UBI image . Run the following command.
+
+```
+make antrea-build
+```
+
 ## Try it out on OpenShift 4 cluster
 
 For Openshift 4 clusters, antrea operator will be deployed in the early phases

--- a/build/antrea/Dockerfile.ubi
+++ b/build/antrea/Dockerfile.ubi
@@ -1,0 +1,22 @@
+FROM golang:1.15 as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-agent antrea-controller antrea-cni antctl-linux
+
+
+FROM antrea/base-ubi:2.14.0
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the Antrea CNI. "
+
+USER root
+
+COPY build/images/scripts/* /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/* /usr/local/bin/

--- a/build/antrea/base/Dockerfile.ubi
+++ b/build/antrea/base/Dockerfile.ubi
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04 as cni-binaries
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates
+
+# Leading dot is required for the tar command below
+ENV CNI_PLUGINS="./host-local ./loopback ./portmap ./bandwidth"
+
+RUN mkdir -p /opt/cni/bin && \
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+
+
+FROM antrea/ovs-ubi:2.14.0
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="Takes care of building the Antrea binaries as part of building the image."
+
+USER root
+
+RUN yum install ipset jq -y
+
+COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin

--- a/build/antrea/build_ubi.sh
+++ b/build/antrea/build_ubi.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+set -e
+
+_usage="Usage: $0 [--tag <ImageTag>] [--antrea-version <AntreaVersion>] 
+Generate Antrea UBI image.
+       --tag                                                   Specify the ip of vc.
+       --antrea-version                                        Specify the password of vc.
+       --help, -h                                              Print usage message.
+"
+
+function print_usage {
+    echo "$_usage"
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --tag)
+    IMAGE_TAG="$2"
+    shift 2
+    ;;
+    --antrea-version)
+    ANTREA_VERSION="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echo "Unknown option $1, try '$0 --help' for more information."
+    exit 1
+    ;;
+esac
+done
+
+if [ -z "${IMAGE_TAG}" ]; then
+  IMAGE_TAG="latest"
+  echo "Using default image tag ${IMAGE_TAG}."
+fi
+
+if [ -z "${ANTREA_VERSION}" ]; then
+  ANTREA_VERSION="0.13.1"
+  echo "Using default Antrea version ${ANTREA_VERSION}."
+fi
+
+wget https://github.com/antrea-io/antrea/archive/refs/tags/v${ANTREA_VERSION}.tar.gz && 
+tar -xzvf v${ANTREA_VERSION}.tar.gz
+
+docker build -t antrea/ovs-ubi:2.14.0 -f ./ovs/Dockerfile.ubi ./ovs
+docker build -t antrea/base-ubi:2.14.0 -f ./base/Dockerfile.ubi ./base
+docker build -t antrea/antrea-ubi:${IMAGE_TAG} -f ./Dockerfile.ubi ./antrea-${ANTREA_VERSION}

--- a/build/antrea/ovs/CentOS.repo
+++ b/build/antrea/ovs/CentOS.repo
@@ -1,0 +1,31 @@
+[AppStream]
+name=CentOS-$releasever - AppStream
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[BaseOS]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[powertools]
+name=CentOS Linux $releasever - PowerTools
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/build/antrea/ovs/Dockerfile.ubi
+++ b/build/antrea/ovs/Dockerfile.ubi
@@ -1,0 +1,49 @@
+FROM registry.access.redhat.com/ubi8 as base-rpms
+
+COPY CentOS.repo /tmp/CentOS.repo
+RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo && \
+    curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    subscription-manager config --rhsm.manage_repos=0 && \ 
+    yum clean all -y && yum update -y
+
+# Download dependencies for ovs.
+RUN yum install -y epel-release && \ 
+    yum install -y --downloadonly --downloaddir="/tmp/build-packages" unbound python3-sphinx desktop-file-utils groff graphviz selinux-policy-devel && \
+    yum install -y --downloadonly --downloaddir="/tmp/install-packages" strongswan libreswan unbound
+
+FROM registry.access.redhat.com/ubi8 as ovs-rpms
+
+# Some patches may not apply cleanly if another version is provided.
+ARG OVS_VERSION=2.14.0
+
+COPY --from=base-rpms /tmp/build-packages/* /tmp/packages/
+COPY apply-patches.sh /
+RUN yum update -y && yum install wget git yum-utils python38 rpm-build -y && yum install -y /tmp/packages/*
+# Download OVS source code
+RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp
+RUN cd /tmp/openvswitch* && \
+    /apply-patches.sh && \
+    sed -e "s/@VERSION@/$OVS_VERSION/" rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
+    yum-builddep -y /tmp/ovs.spec && ./boot.sh && ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc && \
+    make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
+    mv /tmp/openvswitch-$OVS_VERSION/rpm/rpmbuild/RPMS/*/*.rpm  /tmp/ovs-rpms && \
+    rm -rf /tmp/openvswitch*
+
+
+FROM registry.access.redhat.com/ubi8
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image based on UBI8 which includes Open vSwitch built from source."
+
+RUN yum clean all -y && yum update -y && yum reinstall yum -y
+
+COPY charon-logging.conf /tmp
+COPY --from=base-rpms /tmp/install-packages/* /tmp/packages/
+COPY --from=ovs-rpms /tmp/ovs-rpms/* /tmp/ovs-rpms/
+RUN yum install /tmp/packages/* -y && \
+    yum install /tmp/ovs-rpms/* -y && \
+    yum install iptables -y && \
+    yum install logrotate -y && \
+    mv /etc/logrotate.d/openvswitch /etc/logrotate.d/openvswitch-switch && \
+    sed -i "/rotate /a\    #size 100M" /etc/logrotate.d/openvswitch-switch && \
+    rm -rf /tmp/*

--- a/build/antrea/ovs/apply-patches.sh
+++ b/build/antrea/ovs/apply-patches.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script applies unreleased patches (or released in a more recent version
+# of OVS than the one Antrea is using) to OVS before building it. It needs to be
+# run from the root of the OVS source tree.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+# Inspired from https://stackoverflow.com/a/24067243/4538702
+# 'sort -V' is available on Ubuntu 20.04
+# less than
+function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
+# greater than
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+# less than or equal to
+function version_let() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1"; }
+# greater than or equal to
+function version_get() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"; }
+
+if version_lt "$OVS_VERSION" "2.13.0" || version_gt "$OVS_VERSION" "2.14.0"; then
+    echoerr "OVS_VERSION $OVS_VERSION is not supported (must be >= 2.13.0 and <= 2.14.0)"
+    exit 1
+fi
+
+# We cannot use 3-way merge unless we are in a git repository. If we need 3-way
+# merge, we will need to clone the repository with git instead of downloading a
+# release tarball (see Dockerfile).
+
+# This patch (post 2.13.0) ensures that ct_nw_src/ct_nw_dst supports IP Mask.
+if version_let "$OVS_VERSION" "2.13.0"; then
+    curl https://github.com/openvswitch/ovs/commit/1740aaf49dad6f533705dc3dce8d955a1840052a.patch | \
+        git apply
+fi
+
+if version_get "$OVS_VERSION" "2.13.0" && version_lt "$OVS_VERSION" "2.14.0" ; then
+    # These 2 patches (post 2.13.x) ensures that datapath flows are not deleted on
+    # ovs-vswitchd exit by default. Antrea relies on this to support hitless upgrade
+    # of the Agent DaemonSet.
+    # The second patch depends on the first one.
+    curl https://github.com/openvswitch/ovs/commit/586cd3101e7fda54d14fb5bf12d847f35d968627.patch | \
+        git apply
+    # We exclude 2 files which are likely to cause conflicts.
+    curl https://github.com/openvswitch/ovs/commit/79eadafeb1b47a3871cb792aa972f6e4d89d1a0b.patch | \
+        git apply --exclude NEWS --exclude vswitchd/ovs-vswitchd.8.in
+
+    # This patch (post 2.13.x) ensures that ovs-vswitchd does not delete datapath
+    # ports on exit.
+    curl https://github.com/openvswitch/ovs/commit/7cc77b301f80a63cd4893198d82be0eef303f731.patch | \
+        git apply
+
+    # These patches (post 2.13.x) are needed to fix the debian build on Ubuntu 20.04.
+    curl https://github.com/openvswitch/ovs/commit/c101cd4171cfe04e214f858b4bbe089e56f13f9b.patch | \
+        git apply
+    curl https://github.com/openvswitch/ovs/commit/3c18bb0fe9f23308061217f72e2245f0e311b20b.patch | \
+        git apply
+    curl https://github.com/openvswitch/ovs/commit/fe175ac17352ceb2dbc9958112b4b1bc114d82f0.patch | \
+        git apply
+
+    # The OVS ovs-monitor-ipsec script has a Python3 shebang but still includes some Python2-specific code.
+    # Until the patch which fixes the script is merged upstream, we apply it here, or Antrea IPsec support will be broken.
+    curl https://github.com/openvswitch/ovs/commit/8a09c2590ef2ea0edc250ec46e3d41bd5874b4ab.patch | \
+        git apply
+fi
+
+# Starting from version 5.7.0, strongSwan no longer supports specifying a configuration parameter
+# with the path delimited by dots in a configuration file. This patch fixes the strongSwan
+# configuration parameters that ovs-monitor-ipsec writes, to comply with the new strongSwan format.
+# After a new OVS release with the fix is available, we should switch to use that OVS release, and
+# remove the workaround to apply the patch here.
+curl https://github.com/openvswitch/ovs/commit/b424becaac58d8cb08fb19ea839be6807d3ed57f.patch | \
+    git apply
+
+# OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
+# does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,
+# but this seems like an acceptable workaround.
+sed -i 's/python3\.7/python3\.8/' debian/openvswitch-test.install
+sed -i 's/python3\.7/python3\.8/' debian/python3-openvswitch.install

--- a/build/antrea/ovs/charon-logging.conf
+++ b/build/antrea/ovs/charon-logging.conf
@@ -1,0 +1,12 @@
+        charon {
+            path = /var/log/strongswan/charon.log
+            # default log level for all daemon subsystems
+            default = 1
+            # flush each line to disk
+            flush_line = yes
+            # prepend connection name
+            ike_name = yes
+            # prepend timestamp
+            time_format = %b %e %T
+            time_add_ms = yes
+        }


### PR DESCRIPTION
This patch is used for building Antrea UBI image, the basic steps are:
  1. Download missed rpms from CentOS repo with their dependencies in base-rpms.
  2. Copy the rpms for building ovs to the next layer and build ovs-rpms.
  3. Install ovs-rpms to get ovs-ubi.
  4. Based on ovs-ubi, install cni binaries to get base-ubi.
  5. Based on base-ubi, build Antrea to get the final ubi image.