### PR TITLE
update Dockerfile for specifying OVS and CNI version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docker-build:
 	docker tag ${IMG} antrea/antrea-operator
 
 antrea-build:
-	cd build/antrea && ./build_ubi.sh --tag ${TAG} --antrea-version ${VERSION}
+	cd build/antrea && ./build_ubi.sh --tag ${TAG} --antrea-version ${ANTREA_VERSION} --ovs-version ${OVS_VERSION} --cni-version ${CNI_VERSION}
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/build/antrea/Dockerfile.ubi
+++ b/build/antrea/Dockerfile.ubi
@@ -1,3 +1,4 @@
+ARG OVS_VERSION
 FROM golang:1.15 as antrea-build
 
 WORKDIR /antrea
@@ -11,7 +12,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-linux
 
 
-FROM antrea/base-ubi:2.14.0
+FROM antrea/base-ubi:${OVS_VERSION}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/antrea/base/Dockerfile.ubi
+++ b/build/antrea/base/Dockerfile.ubi
@@ -1,4 +1,7 @@
+ARG OVS_VERSION
 FROM ubuntu:20.04 as cni-binaries
+
+ARG CNI_BINARIES_VERSION
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates
@@ -6,11 +9,19 @@ RUN apt-get update && \
 # Leading dot is required for the tar command below
 ENV CNI_PLUGINS="./host-local ./loopback ./portmap ./bandwidth"
 
-RUN mkdir -p /opt/cni/bin && \
-    wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+         amd64) pluginsArch='amd64' ;; \
+	 armhf) pluginsArch='arm' ;; \
+	 arm64) pluginsArch='arm64' ;; \
+         *) pluginsArch=''; echo >&2; echo >&2 "unsupported architecture '$dpkgArch'"; echo >&2 ; exit 1 ;; \
+    esac; \
+    mkdir -p /opt/cni/bin; \
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
+    wget -q -O - https://downloads.antrea.io/whereabouts/v0.4/whereabouts-linux-${pluginsArch}.tgz | tar xz -C /opt/cni/bin/ whereabouts-linux-${pluginsArch}/whereabouts --strip-components=1 --no-same-owner
 
-
-FROM antrea/ovs-ubi:2.14.0
+FROM antrea/ovs-ubi:${OVS_VERSION}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="Takes care of building the Antrea binaries as part of building the image."

--- a/build/antrea/build_ubi.sh
+++ b/build/antrea/build_ubi.sh
@@ -2,10 +2,13 @@
 
 set -e
 
-_usage="Usage: $0 [--tag <ImageTag>] [--antrea-version <AntreaVersion>] 
+_usage="Usage: $0 [--tag <ImageTag>] [--antrea-version <AntreaVersion>] [--ovs-version <Version>] 
+                  [--cni-version <Version> ]
 Generate Antrea UBI image.
-       --tag                                                   Specify the ip of vc.
-       --antrea-version                                        Specify the password of vc.
+       --tag                                                   Specify the image tag.
+       --antrea-version                                        Specify Antrea version.
+       --ovs-version                                           Specify the OVS version.
+       --cni-version                                           Specify the CNI version.
        --help, -h                                              Print usage message.
 "
 
@@ -23,6 +26,14 @@ case $key in
     ;;
     --antrea-version)
     ANTREA_VERSION="$2"
+    shift 2
+    ;;
+    --ovs-version)
+    OVS_VERSION="$2"
+    shift 2
+    ;;
+    --cni-version)
+    CNI_VERSION="$2"
     shift 2
     ;;
     -h|--help)
@@ -46,9 +57,19 @@ if [ -z "${ANTREA_VERSION}" ]; then
   echo "Using default Antrea version ${ANTREA_VERSION}."
 fi
 
+if [ -z "${OVS_VERSION}" ]; then
+  OVS_VERSION="2.14.2"
+  echo "Using default OVS version ${OVS_VERSION}."
+fi
+
+if [ -z "${CNI_VERSION}" ]; then
+  CNI_VERSION="V0.8.7"
+  echo "Using default CNI version ${CNI_VERSION}."
+fi
+
 wget https://github.com/antrea-io/antrea/archive/refs/tags/v${ANTREA_VERSION}.tar.gz && 
 tar -xzvf v${ANTREA_VERSION}.tar.gz
 
-docker build -t antrea/ovs-ubi:2.14.0 -f ./ovs/Dockerfile.ubi ./ovs
-docker build -t antrea/base-ubi:2.14.0 -f ./base/Dockerfile.ubi ./base
-docker build -t antrea/antrea-ubi:${IMAGE_TAG} -f ./Dockerfile.ubi ./antrea-${ANTREA_VERSION}
+docker build -t antrea/ovs-ubi:${OVS_VERSION} --build-arg OVS_VERSION=${OVS_VERSION} -f ./ovs/Dockerfile.ubi ./ovs
+docker build -t antrea/base-ubi:${OVS_VERSION} --build-arg OVS_VERSION=${OVS_VERSION} --build-arg CNI_BINARIES_VERSION=${CNI_VERSION} -f ./base/Dockerfile.ubi ./base
+docker build -t antrea/antrea-ubi:${IMAGE_TAG} --build-arg OVS_VERSION=${OVS_VERSION} -f ./Dockerfile.ubi ./antrea-${ANTREA_VERSION}

--- a/build/antrea/ovs/Dockerfile.ubi
+++ b/build/antrea/ovs/Dockerfile.ubi
@@ -14,7 +14,7 @@ RUN yum install -y epel-release && \
 FROM registry.access.redhat.com/ubi8 as ovs-rpms
 
 # Some patches may not apply cleanly if another version is provided.
-ARG OVS_VERSION=2.14.0
+ARG OVS_VERSION
 
 COPY --from=base-rpms /tmp/build-packages/* /tmp/packages/
 COPY apply-patches.sh /

--- a/build/antrea/ovs/apply-patches.sh
+++ b/build/antrea/ovs/apply-patches.sh
@@ -35,8 +35,8 @@ function version_let() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "
 # greater than or equal to
 function version_get() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"; }
 
-if version_lt "$OVS_VERSION" "2.13.0" || version_gt "$OVS_VERSION" "2.14.0"; then
-    echoerr "OVS_VERSION $OVS_VERSION is not supported (must be >= 2.13.0 and <= 2.14.0)"
+if version_lt "$OVS_VERSION" "2.13.0" || version_get "$OVS_VERSION" "2.15.0"; then
+    echoerr "OVS_VERSION $OVS_VERSION is not supported (must be >= 2.13.0 and < 2.15.0)"
     exit 1
 fi
 
@@ -83,10 +83,10 @@ fi
 # Starting from version 5.7.0, strongSwan no longer supports specifying a configuration parameter
 # with the path delimited by dots in a configuration file. This patch fixes the strongSwan
 # configuration parameters that ovs-monitor-ipsec writes, to comply with the new strongSwan format.
-# After a new OVS release with the fix is available, we should switch to use that OVS release, and
-# remove the workaround to apply the patch here.
-curl https://github.com/openvswitch/ovs/commit/b424becaac58d8cb08fb19ea839be6807d3ed57f.patch | \
-    git apply
+if version_lt "$OVS_VERSION" "2.14.1" ; then
+    curl https://github.com/openvswitch/ovs/commit/b424becaac58d8cb08fb19ea839be6807d3ed57f.patch | \
+        git apply
+fi
 
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
 # does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,


### PR DESCRIPTION
The version of OVS and CNI can be specified by user for building
Antrea UBI image.