### PR TITLE
Automate generation of antrea manifest template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### kube cache ###
 .kube
+### kustomize image ###
+hack/.bin/kustomize

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 	docker tag ${BUNDLE_IMG} antrea/antrea-operator-bundle
 
+.PHONY: antrea-manifest
+antrea-manifest:
+	./hack/generate-manifest.sh > ./antrea-manifest/antrea.yml
+
 # Generate package manifests.
 packagemanifests: kustomize manifests
 	operator-sdk generate kustomize manifests -q

--- a/antrea-manifest/antrea.yml
+++ b/antrea-manifest/antrea.yml
@@ -616,6 +616,30 @@ spec:
                               match:
                                 type: string
                             type: object
+                          nodeSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           podSelector:
                             properties:
                               matchExpressions:
@@ -786,6 +810,30 @@ spec:
                                 enum:
                                 - Self
                                 type: string
+                            type: object
+                          nodeSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                x-kubernetes-preserve-unknown-fields: true
                             type: object
                           podSelector:
                             properties:
@@ -1206,7 +1254,9 @@ spec:
                       - format: ipv6
                       type: string
                     vlan:
-                      type: string
+                      maximum: 4094
+                      minimum: 0
+                      type: integer
                   type: object
                 type: array
               ipVersion:
@@ -1447,6 +1497,30 @@ spec:
                               matchLabels:
                                 x-kubernetes-preserve-unknown-fields: true
                             type: object
+                          nodeSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
                           podSelector:
                             properties:
                               matchExpressions:
@@ -1563,6 +1637,30 @@ spec:
                                 type: string
                             type: object
                           namespaceSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      enum:
+                                      - In
+                                      - NotIn
+                                      - Exists
+                                      - DoesNotExist
+                                      type: string
+                                    values:
+                                      items:
+                                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              matchLabels:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          nodeSelector:
                             properties:
                               matchExpressions:
                                 items:
@@ -2171,6 +2269,11 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
   - patch
 - apiGroups:
   - ""
@@ -2180,6 +2283,11 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
   - patch
 - apiGroups:
   - ""
@@ -2197,7 +2305,6 @@ rules:
   - services/status
   verbs:
   - update
-  - patch
 - apiGroups:
   - discovery.k8s.io
   resources:
@@ -2356,6 +2463,7 @@ rules:
   - ""
   resources:
   - pods
+  - services
   - namespaces
   - configmaps
   verbs:
@@ -2374,14 +2482,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - services
   - services/status
   verbs:
-  - get
-  - watch
-  - list
   - update
-  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -2641,10 +2744,9 @@ data:
 {{.AntreaControllerConfig | indent 4}}
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
-  name: antrea-config-82b78c27h8
+  name: antrea-config-84c89k9k9m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2666,13 +2768,13 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
   labels:
     app: antrea
     component: antrea-controller
   name: antrea-controller
   namespace: kube-system
-  annotations:
-    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   replicas: 1
   selector:
@@ -2717,7 +2819,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-82b78c27h8
+          value: antrea-config-84c89k9k9m
         image: {{.AntreaImage}}
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -2768,7 +2870,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-82b78c27h8
+          name: antrea-config-84c89k9k9m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -2828,13 +2930,13 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
   labels:
     app: antrea
     component: antrea-agent
   name: antrea-agent
   namespace: kube-system
-  annotations:
-    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:
@@ -2969,6 +3071,9 @@ spec:
       initContainers:
       - command:
         - install_cni
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: {{.AntreaImage}}
         imagePullPolicy: IfNotPresent
         name: install-cni
@@ -3005,15 +3110,15 @@ spec:
       - effect: NoExecute
         operator: Exists
       volumes:
-      - configMap:
-          name: antrea-config-82b78c27h8
-        name: antrea-config
-      - hostPath:
-          path: {{.CNIConfDir}}
-        name: host-cni-conf
       - hostPath:
           path: {{.CNIBinDir}}
         name: host-cni-bin
+      - hostPath:
+          path: {{.CNIConfDir}}
+        name: host-cni-conf
+      - configMap:
+          name: antrea-config-84c89k9k9m
+        name: antrea-config
       - hostPath:
           path: /proc
         name: host-proc

--- a/build/yamls/patches/agentImage.yml
+++ b/build/yamls/patches/agentImage.yml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-agent
+          image: "{{.AntreaImage}}"

--- a/build/yamls/patches/agentOcpRelease.yml
+++ b/build/yamls/patches/agentOcpRelease.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+  annotations:
+    release.openshift.io/version: \"{{.ReleaseVersion}}\"

--- a/build/yamls/patches/controllerImage.yml
+++ b/build/yamls/patches/controllerImage.yml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-controller
+          image: "{{.AntreaImage}}"

--- a/build/yamls/patches/controllerOsRelease.yml
+++ b/build/yamls/patches/controllerOsRelease.yml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-controller
+  annotations:
+    release.openshift.io/version: \"{{.ReleaseVersion}}\"

--- a/build/yamls/patches/installCniBinDir.yml
+++ b/build/yamls/patches/installCniBinDir.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      volumes:
+        - hostPath:
+            path: "{{.CNIBinDir}}"
+          name: host-cni-bin

--- a/build/yamls/patches/installCniConfDir.yml
+++ b/build/yamls/patches/installCniConfDir.yml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      volumes:
+        - hostPath:
+            path: "{{.CNIConfDir}}"
+          name: host-cni-conf

--- a/build/yamls/patches/installCniImage.yml
+++ b/build/yamls/patches/installCniImage.yml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: install-cni
+          image: "{{.AntreaImage}}"

--- a/build/yamls/patches/ovsImage.yml
+++ b/build/yamls/patches/ovsImage.yml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+        - name: antrea-ovs
+          image: "{{.AntreaImage}}"

--- a/build/yamls/patches/templates/kustomization.configMap.tpl.yml
+++ b/build/yamls/patches/templates/kustomization.configMap.tpl.yml
@@ -1,0 +1,7 @@
+configMapGenerator:
+- name: antrea-config
+  behavior: merge
+  files:
+  - <AGENT_CONF_FILE>
+  - <CONTROLLER_CONF_FILE>
+  - <CNI_CONFLIST_FILE>

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--version <antrea version>] [--help|-h]
+Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
+        --version                     Antrea version for use for manifest generation
+        --help, -h                    Print this message and exit
+
+This tool uses kustomize (https://github.com/kubernetes-sigs/kustomize) to generate manifests for
+Antrea. You can set the KUSTOMIZE environment variable to the path of the kustomize binary you want
+us to use. Otherwise we will download the appropriate version of the kustomize binary and use
+it (this is the recommended approach since different versions of kustomize may create different
+output YAMLs)."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+MODE="dev"
+ANTREA_VERSION="main"
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --version)
+    ANTREA_VERSION="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/verify-kustomize.sh
+
+if [ -z "$KUSTOMIZE" ]; then
+    KUSTOMIZE="$(verify_kustomize)"
+elif ! $KUSTOMIZE version > /dev/null 2>&1; then
+    echoerr "$KUSTOMIZE does not appear to be a valid kustomize binary"
+    print_help
+    exit 1
+fi
+
+# Get Antrea repository
+ANTREA_DIR=$(mktemp -d /tmp/antrea.XXXXXXX)
+
+if [ "$ANTREA_VERSION" == "main" ]; then
+    ANTREA_URL="https://github.com/antrea-io/antrea/archive/refs/heads/main.tar.gz"
+    ANTREA_ROOT=$ANTREA_DIR/antrea-main
+else
+    ANTREA_URL="https://github.com/antrea-io/antrea/archive/refs/tags/v${ANTREA_VERSION}.tar.gz"
+    ANTREA_ROOT=$ANTREA_DIR/antrea-v$ANTREA_VERSION
+fi
+curl -sL $ANTREA_URL | tar xz -C $ANTREA_DIR
+
+KUSTOMIZATION_DIR=$ANTREA_ROOT/build/yamls
+
+TMP_DIR=$(mktemp -d $KUSTOMIZATION_DIR/overlays.XXXXXXXX)
+
+pushd $TMP_DIR > /dev/null
+
+BASE=../../base
+
+# do all ConfigMap edits
+mkdir configMap && cd configMap
+
+# OpenShift operator implants the configurations so here just add placeholders
+echo "{{.AntreaAgentConfig | indent 4}}" > antrea-agent.conf
+echo "{{.AntreaControllerConfig | indent 4}}" > antrea-controller.conf
+echo "{{.AntreaCNIConfig | indent 4}}" > antrea-cni.conflist
+
+# unfortunately 'kustomize edit add configmap' does not support specifying 'merge' as the behavior,
+# which is why we use a template kustomization file.
+sed -e "s/<AGENT_CONF_FILE>/antrea-agent.conf/; s/<CONTROLLER_CONF_FILE>/antrea-controller.conf/; s/<CNI_CONFLIST_FILE>/antrea-cni.conflist/" $THIS_DIR/../build/yamls/patches/templates/kustomization.configMap.tpl.yml > kustomization.yml
+$KUSTOMIZE edit add base $BASE
+BASE=../configMap
+cd ..
+
+mkdir osmft && cd osmft
+cp $THIS_DIR/../build/yamls/patches/*.yml .
+touch kustomization.yml
+$KUSTOMIZE edit add base $BASE
+$KUSTOMIZE edit add patch --path agentOcpRelease.yml
+$KUSTOMIZE edit add patch --path agentImage.yml
+$KUSTOMIZE edit add patch --path ovsImage.yml
+$KUSTOMIZE edit add patch --path installCniImage.yml
+$KUSTOMIZE edit add patch --path installCniConfDir.yml
+$KUSTOMIZE edit add patch --path installCniBinDir.yml
+$KUSTOMIZE edit add patch --path controllerOsRelease.yml
+$KUSTOMIZE edit add patch --path controllerImage.yml
+BASE=../osmft
+cd ..
+
+mkdir $MODE && cd $MODE
+touch kustomization.yml
+$KUSTOMIZE edit add base $BASE
+
+find ../../patches/$MODE -name \*.yml -exec cp {} . \;
+
+$KUSTOMIZE edit add patch --path agentImagePullPolicy.yml
+$KUSTOMIZE edit add patch --path controllerImagePullPolicy.yml
+
+$KUSTOMIZE build | sed 's/^\s*{{/{{/; s/\\"\({{.*}}\)\\"/"\1"/; '"s/'\({{.*}}\)'/\1/"
+
+popd > /dev/null
+
+rm -rf $TMP_DIR $ANTREA_DIR

--- a/hack/verify-kustomize.sh
+++ b/hack/verify-kustomize.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+_BINDIR="$THIS_DIR/.bin"
+# Must be an exact match, as the generated YAMLs may not be consistent across
+# versions
+_KUSTOMIZE_VERSION="v4.4.1"
+
+# Ensure the kustomize tool exists and is the correct version, or installs it
+verify_kustomize() {
+    # Check if there is already a kustomize binary in $_BINDIR and if yes, check
+    # if the version matches the expected one.
+    local kustomize="$(PATH=$_BINDIR command -v kustomize)"
+    if [ -x "$kustomize" ]; then
+        # Verify version if kustomize was already installed.
+        local kustomize_version="$($kustomize version --short)"
+        kustomize_version="${kustomize_version##*/}"
+        kustomize_version="${kustomize_version%% *}"
+        if [ "${kustomize_version}" == "${_KUSTOMIZE_VERSION}" ]; then
+            # If version is exact match, stop here.
+            echo "$kustomize"
+            return 0
+        fi
+        >&2 echo "Detected kustomize version ($kustomize_version) does not match expected one ($_KUSTOMIZE_VERSION), installing correct version"
+    fi
+    local ostype=""
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        ostype="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ostype="darwin"
+    else
+        >&2 echo "Unsupported OS type $OSTYPE"
+        return 1
+    fi
+    >&2 echo "Installing kustomize"
+    local kustomize_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${_KUSTOMIZE_VERSION}/kustomize_${_KUSTOMIZE_VERSION}_${ostype}_amd64.tar.gz"
+    curl -sLo kustomize.tar.gz "${kustomize_url}" || return 1
+    mkdir -p "$_BINDIR" || return 1
+    tar -xzf kustomize.tar.gz -C "$_BINDIR" || return 1
+    rm -f kustomize.tar.gz
+    kustomize="$_BINDIR/kustomize"
+    echo "$kustomize"
+    return 0
+}


### PR DESCRIPTION
antrea-manifest/antrea.yml is a template file which is based on contents
from Antrea repository.

This template file should be in sync with the contents in the antrea
repo, and this PR automates the synchronization of the file with the
Antrea repo.

To generate the manifest, use hack/generate-manifest.sh
Alternately use make antrea-manifest target to build the manifest and
put it in place into antrea-manifest dir.

Signed-off-by: Kobi Samoray <ksamoray@vmware.com>