### PR TITLE
Fix issues imported by upgrading Openshift modules

### DIFF
--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -51,7 +51,7 @@ func fillAgentConfig(clusterConfig *configv1.Network, operConfig *operatorv1.Ant
 		if serviceCIDR, ok := antreaAgentConfig[types.ServiceCIDROption].(string); !ok {
 			antreaAgentConfig[types.ServiceCIDROption] = clusterConfig.Spec.ServiceNetwork[0]
 		} else if found := inSlice(serviceCIDR, clusterConfig.Spec.ServiceNetwork); !found {
-			log.Info("WARNING: option: %s is overwritten by cluster config")
+			log.Info("WARNING: ServiceCIDROption is overwritten by cluster config")
 			antreaAgentConfig[types.ServiceCIDROption] = clusterConfig.Spec.ServiceNetwork[0]
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	ocoperv1 "github.com/openshift/api/operator/v1"
 	cnoclient "github.com/openshift/cluster-network-operator/pkg/client"
 	"github.com/openshift/cluster-network-operator/pkg/names"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -28,7 +27,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = clientgoscheme.Scheme
 	setupLog = ctrl.Log.WithName("setup")
 )
 


### PR DESCRIPTION
1. Fix 'AntreaInstall is not registered to scheme' issue. OperatorClusterClient is used to perform CRUD operations after upgrading, and OperatorClusterClient uses global scheme(aka `scheme.Scheme`) to register CRD. But antrea-operator creates a new scheme by `scheme := runtime.NewScheme()`, which finally causes that CRD is not registered to the scheme used by OperatorClusterClient. To fix this, antrea-operator uses the same scheme as OperatorClusterClient.
2. Function 'apply.ApplyObject' updates its interface to receive type 'Object', so there is no need to convert 'Object' to 'Unstructured'.