### PR TITLE
Generate human-readable antrea-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ bundle-build:
 antrea-resources:
 	./hack/generate-antrea-resources.sh --platform $(ANTREA_PLATFORM) --version $(VERSION)
 	cp ./config/rbac/role.yaml ./deploy/$(ANTREA_PLATFORM)/role.yaml
+	cp ./config/samples/operator_v1_antreainstall.yaml ./deploy/$(ANTREA_PLATFORM)/operator.antrea.vmware.com_v1_antreainstall_cr.yaml
 
 # Generate package manifests.
 packagemanifests: kustomize manifests

--- a/antrea-manifest/antrea.yml
+++ b/antrea-manifest/antrea.yml
@@ -758,6 +758,9 @@ spec:
                           namespace:
                             type: string
                           scope:
+                            enum:
+                            - Cluster
+                            - ClusterSet
                             type: string
                         required:
                         - name
@@ -3838,11 +3841,11 @@ subjects:
 apiVersion: v1
 data:
   antrea-agent.conf: |
-{{.AntreaAgentConfig | indent 4}}
+    {{.AntreaAgentConfig | indent 4}}
   antrea-cni.conflist: |
-{{.AntreaCNIConfig | indent 4}}
+    {{.AntreaCNIConfig | indent 4}}
   antrea-controller.conf: |
-{{.AntreaControllerConfig | indent 4}}
+    {{.AntreaControllerConfig | indent 4}}
 kind: ConfigMap
 metadata:
   labels:
@@ -3905,7 +3908,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc23e723afc8c100dc8bdc6b2f8a2774baf7dcf7a8eb0a34e168057d75b9f245
+        checksum/config: 2c1c5158b6a3ea32eff58bc1e498592e80ebecee07f51b10c722b67afce7b964
       labels:
         app: antrea
         component: antrea-controller
@@ -4066,7 +4069,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc23e723afc8c100dc8bdc6b2f8a2774baf7dcf7a8eb0a34e168057d75b9f245
+        checksum/config: 2c1c5158b6a3ea32eff58bc1e498592e80ebecee07f51b10c722b67afce7b964
         kubectl.kubernetes.io/default-container: antrea-agent
       labels:
         app: antrea
@@ -4186,7 +4189,6 @@ spec:
         - mountPath: /var/log/openvswitch
           name: host-var-log-antrea
           subPath: openvswitch
-      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       initContainers:
       - command:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,28 +1,103 @@
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: antrea-operator
 rules:
-- nonResourceURLs:
-  - /addressgroups
-  - /agentinfo
-  - /appliedtogroups
-  - /networkpolicies
-  - /ovsflows
-  - /ovstracing
-  - /podinterfaces
-  verbs:
-  - get
 - apiGroups:
-  - ""
+  - ''
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ''
+  resources:
   - namespaces
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
   - pods
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods/status
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - services
   verbs:
   - create
@@ -34,20 +109,30 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
+  - ''
   resources:
-  - nodes
+  - services/status
   verbs:
-  - get
-  - list
-  - watch
+  - update
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
   - validatingwebhookconfigurations
   verbs:
   - create
+  - get
+  - patch
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -68,11 +153,23 @@ rules:
   - create
   - delete
   - get
+  - patch
   - update
 - apiGroups:
   - apps
   resources:
   - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -83,17 +180,60 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
   verbs:
   - create
+  - patch
 - apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
   verbs:
   - create
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  verbs:
+  - approve
+  - sign
+  - patch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -118,6 +258,15 @@ rules:
   - config.openshift.io
   resources:
   - networks
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - networks/finalizers
   verbs:
   - get
@@ -129,37 +278,283 @@ rules:
   - controlplane.antrea.io
   resources:
   - addressgroups
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
   - appliedtogroups
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - egressgroups
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
   - networkpolicies
   verbs:
   - delete
   - get
   - list
+  - patch
   - watch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - networkpolicies/status
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - nodestatssummaries
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - supportbundlecollections
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - controlplane.antrea.io
+  resources:
+  - supportbundlecollections/status
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - crd.antrea.io
   resources:
   - antreaagentinfos
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - crd.antrea.io
+  resources:
   - antreacontrollerinfos
   verbs:
   - create
   - delete
   - get
   - list
+  - patch
   - update
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - clustergroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - clustergroups/status
+  verbs:
+  - update
+  - patch
 - apiGroups:
   - crd.antrea.io
   resources:
   - clusternetworkpolicies
   verbs:
+  - create
   - delete
   - get
   - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - clusternetworkpolicies/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - egresses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - egresses/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalentities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalippools
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalippools/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - externalnodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - groups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - groups/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - ippools
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - ippools/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - networkpolicies/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - supportbundlecollections
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - supportbundlecollections/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - crd.antrea.io
+  resources:
+  - tiers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - crd.antrea.io
   resources:
   - traceflows
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - crd.antrea.io
+  resources:
   - traceflows/status
   verbs:
   - create
@@ -170,6 +565,60 @@ rules:
   - update
   - watch
 - apiGroups:
+  - crd.antrea.io
+  resources:
+  - trafficcontrols
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterinfoimports
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - labelidentities
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -177,6 +626,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - operator.antrea.vmware.com
   resources:
@@ -211,8 +661,41 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - roles
   verbs:
   - create
@@ -224,21 +707,113 @@ rules:
   - watch
 - apiGroups:
   - security.openshift.io
-  resourceNames:
-  - hostnetwork
   resources:
   - securitycontextconstraints
   verbs:
   - use
+  - patch
+- apiGroups:
+  - stats.antrea.io
+  resources:
+  - antreaclusternetworkpolicystats
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - stats.antrea.io
+  resources:
+  - antreanetworkpolicystats
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - stats.antrea.io
+  resources:
+  - networkpolicystats
+  verbs:
+  - get
+  - list
+  - patch
 - apiGroups:
   - system.antrea.io
   resources:
   - agentinfos
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - post
+  - watch
+- apiGroups:
+  - system.antrea.io
+  resources:
+  - controllerinfos
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - system.antrea.io
+  resources:
   - supportbundles
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - post
+  - watch
+- apiGroups:
+  - system.antrea.io
+  resources:
   - supportbundles/download
   verbs:
   - delete
   - get
   - list
+  - patch
   - post
   - watch
+- nonResourceURLs:
+  - /addressgroups
+  verbs:
+  - get
+- nonResourceURLs:
+  - /agentinfo
+  verbs:
+  - get
+- nonResourceURLs:
+  - /appliedtogroups
+  verbs:
+  - get
+- nonResourceURLs:
+  - /featuregates
+  verbs:
+  - get
+- nonResourceURLs:
+  - /loglevel
+  verbs:
+  - get
+- nonResourceURLs:
+  - /networkpolicies
+  verbs:
+  - get
+- nonResourceURLs:
+  - /ovsflows
+  verbs:
+  - get
+- nonResourceURLs:
+  - /ovstracing
+  verbs:
+  - get
+- nonResourceURLs:
+  - /podinterfaces
+  verbs:
+  - get
+- nonResourceURLs:
+  - /serviceexternalip
+  verbs:
+  - get
+

--- a/config/samples/operator_v1_antreainstall.yaml
+++ b/config/samples/operator_v1_antreainstall.yaml
@@ -4,284 +4,462 @@ metadata:
   name: antrea-install
   namespace: antrea-operator
 spec:
-  antreaAgentConfig: "# FeatureGates is a map of feature names to bools that enable\
-    \ or disable experimental features.\nfeatureGates:\n# AllAlpha is a global toggle\
-    \ for alpha features. Per-feature key values override the default set by AllAlpha.\n\
-    #  AllAlpha: false\n\n# AllBeta is a global toggle for beta features. Per-feature\
-    \ key values override the default set by AllBeta.\n#  AllBeta: false\n\n# Enable\
-    \ AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.\n\
-    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect\
-    \ on\n# Service traffic.\n#  AntreaProxy: true\n\n# Enable EndpointSlice support\
-    \ in AntreaProxy. Don't enable this feature unless that EndpointSlice\n# API version\
-    \ v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,\n\
-    # this flag will not take effect.\n#  EndpointSlice: false\n\n# Enable TopologyAwareHints\
-    \ in AntreaProxy. This requires AntreaProxy and EndpointSlice to be\n# enabled,\
-    \ otherwise this flag will not take effect.\n#  TopologyAwareHints: false\n\n\
-    # Enable traceflow which provides packet tracing feature to diagnose network issue.\n\
-    #  Traceflow: true\n\n# Enable NodePortLocal feature to make the Pods reachable\
-    \ externally through NodePort\n#  NodePortLocal: true\n\n# Enable Antrea ClusterNetworkPolicy\
-    \ feature to complement K8s NetworkPolicy for cluster admins\n# to define security\
-    \ policies which apply to the entire cluster, and Antrea NetworkPolicy\n# feature\
-    \ that supports priorities, rule actions and externalEntities in the future.\n\
-    #  AntreaPolicy: true\n\n# Enable flowexporter which exports polled conntrack\
-    \ connections as IPFIX flow records from each\n# agent to a configured collector.\n\
-    #  FlowExporter: false\n\n# Enable collecting and exposing NetworkPolicy statistics.\n\
-    #  NetworkPolicyStats: true\n\n# Enable controlling SNAT IPs of Pod egress traffic.\n\
-    #  Egress: true\n\n# Enable AntreaIPAM, which can allocate IP addresses from IPPools.\
-    \ AntreaIPAM is required by the\n# bridging mode and allocates IPs to Pods in\
-    \ bridging mode. It is also required to use Antrea for\n# IPAM when configuring\
-    \ secondary network interfaces with Multus.\n#  AntreaIPAM: false\n\n# Enable\
-    \ multicast traffic.\n#  Multicast: false\n\n# Enable Antrea Multi-cluster Gateway\
-    \ to support cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n#  Multicluster: false\n\n# Enable support for provisioning secondary\
-    \ network interfaces for Pods (using\n# Pod annotations). At the moment, Antrea\
-    \ can only create secondary network\n# interfaces using SR-IOV VFs on baremetal\
-    \ Nodes.\n#  SecondaryNetwork: false\n\n# Enable managing external IPs of Services\
-    \ of LoadBalancer type.\n#  ServiceExternalIP: false\n\n# Enable mirroring or\
-    \ redirecting the traffic Pods send or receive.\n#  TrafficControl: false\n\n\
-    # Enable certificated-based authentication for IPsec.\n#  IPsecCertAuth: false\n\
-    \n# Enable collecting support bundle files with SupportBundleCollection CRD.\n\
-    #  SupportBundleCollection: false\n\n# Enable users to protect their applications\
-    \ by specifying how they are allowed to communicate with others, taking\n# into\
-    \ account application context.\n#  L7NetworkPolicy: false\n\n# Name of the OpenVSwitch\
-    \ bridge antrea-agent will create and use.\n# Make sure it doesn't conflict with\
-    \ your existing OpenVSwitch bridges.\novsBridge: \"br-int\"\n\n# Datapath type\
-    \ to use for the OpenVSwitch bridge created by Antrea. At the moment, the only\n\
-    # supported value is 'system', which corresponds to the kernel datapath.\n#ovsDatapathType:\
-    \ system\n\n# Name of the interface antrea-agent will create and use for host\
-    \ <--> pod communication.\n# Make sure it doesn't conflict with your existing\
-    \ interfaces.\nhostGateway: \"antrea-gw0\"\n\n# Determines how traffic is encapsulated.\
-    \ It has the following options:\n# encap(default):    Inter-node Pod traffic is\
-    \ always encapsulated and Pod to external network\n#                    traffic\
-    \ is SNAT'd.\n# noEncap:           Inter-node Pod traffic is not encapsulated;\
-    \ Pod to external network traffic is\n#                    SNAT'd if noSNAT is\
-    \ not set to true. Underlying network must be capable of\n#                  \
-    \  supporting Pod traffic across IP subnets.\n# hybrid:            noEncap if\
-    \ source and destination Nodes are on the same subnet, otherwise encap.\n# networkPolicyOnly:\
-    \ Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates\
-    \ Pod\n#                    IPAM and connectivity to the primary CNI.\n#\ntrafficEncapMode:\
-    \ \"encap\"\n\n# Whether or not to SNAT (using the Node IP) the egress traffic\
-    \ from a Pod to the external network.\n# This option is for the noEncap traffic\
-    \ mode only, and the default value is false. In the noEncap\n# mode, if the cluster's\
-    \ Pod CIDR is reachable from the external network, then the Pod traffic to\n#\
-    \ the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent\
-    \ never\n# performs SNAT and this option will be ignored; for other modes it must\
-    \ be set to false.\nnoSNAT: false\n\n# Tunnel protocols used for encapsulating\
-    \ traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,\n# this\
-    \ option will not take effect. Supported values:\n# - geneve (default)\n# - vxlan\n\
-    # - gre\n# - stt\n# Note that \"gre\" is not supported for IPv6 clusters (IPv6-only\
-    \ or dual-stack clusters).\ntunnelType: \"geneve\"\n\n# TunnelPort is the destination\
-    \ port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).\n# If\
-    \ zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve,\
-    \ 4789 for VXLAN,\n# and 7471 for STT.\ntunnelPort: 0\n\n# TunnelCsum determines\
-    \ whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing\n\
-    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger\
-    \ GRO on the receiver for better\n# performance of Geneve and VXLAN tunnels. The\
-    \ issue has been fixed by\n# https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063,\
-    \ thus computing UDP checksum is\n# no longer necessary.\n# It should only be\
-    \ set to true when you are using an unpatched Linux kernel and observing poor\
-    \ transfer performance.\ntunnelCsum: false\n\n# Determines how tunnel traffic\
-    \ is encrypted. Currently encryption only works with encap mode.\n# It has the\
-    \ following options:\n# - none (default):  Inter-node Pod traffic will not be\
-    \ encrypted.\n# - ipsec:           Enable IPsec (ESP) encryption for Pod traffic\
-    \ across Nodes. Antrea uses\n#                    Preshared Key (PSK) for IKE\
-    \ authentication. When IPsec tunnel is enabled,\n#                    the PSK\
-    \ value must be passed to Antrea Agent through an environment\n#             \
-    \       variable: ANTREA_IPSEC_PSK.\n# - wireGuard:       Enable WireGuard for\
-    \ tunnel traffic encryption.\ntrafficEncryptionMode: \"none\"\n\n# Enable bridging\
-    \ mode of Pod network on Nodes, in which the Node's transport interface is connected\n\
-    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose\
-    \ IP addresses are\n# allocated by AntreaIPAM from IPPools) is sent to the underlay\
-    \ network, and forwarded/routed by the\n# underlay network.\n# This option requires\
-    \ the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only\n\
-    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,\n\
-    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.\nenableBridgingMode:\
-    \ false\n\n# Disable TX checksum offloading for container network interfaces.\
-    \ It's supposed to be set to true when the\n# datapath doesn't support TX checksum\
-    \ offloading, which causes packets to be dropped due to bad checksum.\n# It affects\
-    \ Pods running on Linux Nodes only.\ndisableTXChecksumOffload: false\n\n# Default\
-    \ MTU to use for the host gateway interface and the network interface of each\
-    \ Pod.\n# If omitted, antrea-agent will discover the MTU of the Node's primary\
-    \ interface and\n# also adjust MTU to accommodate for tunnel encapsulation overhead\
-    \ (if applicable).\ndefaultMTU: 0\n\n# wireGuard specifies WireGuard related configurations.\n\
-    wireGuard:\n  # The port for WireGuard to receive traffic.\n  port: 51820\n\n\
-    egress:\n  # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will\
-    \ not be SNAT'd by Egresses.\n  exceptCIDRs:\n\n# ClusterIP CIDR range for Services.\
-    \ It's required when AntreaProxy is not enabled, and should be\n# set to the same\
-    \ value as the one specified by --service-cluster-ip-range for kube-apiserver.\
-    \ When\n# AntreaProxy is enabled, this parameter is not needed and will be ignored\
-    \ if provided.\nserviceCIDR: \"\"\n\n# ClusterIP CIDR range for IPv6 Services.\
-    \ It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack\n\
-    # cluster or an IPv6 only cluster. The value should be the same as the configuration\
-    \ for kube-apiserver specified by\n# --service-cluster-ip-range. When AntreaProxy\
-    \ is enabled, this parameter is not needed.\n# No default value for this field.\n\
-    serviceCIDRv6: \"\"\n\n# The port for the antrea-agent APIServer to serve on.\n\
-    # Note that if it's set to another value, the `containerPort` of the `api` port\
-    \ of the\n# `antrea-agent` container must be set to the same value.\napiPort:\
-    \ 10350\n\n# Enable metrics exposure via Prometheus. Initializes Prometheus metrics\
-    \ listener.\nenablePrometheusMetrics: true\n\n# Provide the IPFIX collector address\
-    \ as a string with format <HOST>:[<PORT>][:<PROTO>].\n# HOST can either be the\
-    \ DNS name or the IP of the Flow Collector. For example,\n# \"flow-aggregator.flow-aggregator.svc\"\
-    \ can be provided as DNS name to connect\n# to the Antrea Flow Aggregator service.\
-    \ If IP, it can be either IPv4 or IPv6.\n# However, IPv6 address should be wrapped\
-    \ with [].\n# If PORT is empty, we default to 4739, the standard IPFIX port.\n\
-    # If no PROTO is given, we consider \"tls\" as default. We support \"tls\", \"\
-    tcp\" and\n# \"udp\" protocols. \"tls\" is used for securing communication between\
-    \ flow exporter and\n# flow aggregator.\nflowCollectorAddr: \"flow-aggregator.flow-aggregator.svc:4739:tls\"\
-    \n\n# Provide flow poll interval as a duration string. This determines how often\
-    \ the\n# flow exporter dumps connections from the conntrack module. Flow poll\
-    \ interval\n# should be greater than or equal to 1s (one second).\n# Valid time\
-    \ units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\nflowPollInterval:\
-    \ \"5s\"\n\n# Provide the active flow export timeout, which is the timeout after\
-    \ which a flow\n# record is sent to the collector for active flows. Thus, for\
-    \ flows with a continuous\n# stream of packets, a flow record will be exported\
-    \ to the collector once the elapsed\n# time since the last export event is equal\
-    \ to the value of this timeout.\n# Valid time units are \"ns\", \"us\" (or \"\xB5\
-    s\"), \"ms\", \"s\", \"m\", \"h\".\nactiveFlowExportTimeout: \"5s\"\n\n# Provide\
-    \ the idle flow export timeout, which is the timeout after which a flow\n# record\
-    \ is sent to the collector for idle flows. A flow is considered idle if no\n#\
-    \ packet matching this flow has been observed since the last export event.\n#\
-    \ Valid time units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"\
-    h\".\nidleFlowExportTimeout: \"15s\"\n\nnodePortLocal:\n# Enable NodePortLocal,\
-    \ a feature used to make Pods reachable using port forwarding on the host. To\n\
-    # enable this feature, you need to set \"enable\" to true, and ensure that the\
-    \ NodePortLocal feature\n# gate is also enabled (which is the default).\n  enable:\
-    \ false\n# Provide the port range used by NodePortLocal. When the NodePortLocal\
-    \ feature is enabled, a port\n# from that range will be assigned whenever a Pod's\
-    \ container defines a specific port to be exposed\n# (each container can define\
-    \ a list of ports as pod.spec.containers[].ports), and all Node traffic\n# directed\
-    \ to that port will be forwarded to the Pod.\n  portRange: \"61000-62000\"\n\n\
-    # Provide the address of Kubernetes apiserver, to override any value provided\
-    \ in kubeconfig or InClusterConfig.\n# Defaults to \"\". It must be a host string,\
-    \ a host:port pair, or a URL to the base of the apiserver.\nkubeAPIServerOverride:\
-    \ \"\"\n\n# Provide the address of DNS server, to override the kube-dns service.\
-    \ It's used to resolve hostname in FQDN policy.\n# Defaults to \"\". It must be\
-    \ a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,\n\
-    # [fd00:10:96::a]:53).\ndnsServerOverride: \"\"\n\n# Comma-separated list of Cipher\
-    \ Suites. If omitted, the default Go Cipher Suites will be used.\n# https://golang.org/pkg/crypto/tls/#pkg-constants\n\
-    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver\
-    \ will always\n# prefer TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites:\
-    \ \"\"\n\n# TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\n\
-    tlsMinVersion: \"\"\n\n# The name of the interface on Node which is used for tunneling\
-    \ or routing the traffic across Nodes.\n# If there are multiple IP addresses configured\
-    \ on the interface, the first one is used. The IP\n# address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterface: \"\"\n\nmulticast:\n# The names of the interfaces\
-    \ on Nodes that are used to forward multicast traffic.\n# Defaults to transport\
-    \ interface if not set.\n  multicastInterfaces:\n\n# The interval at which the\
-    \ antrea-agent sends IGMP queries to Pods.\n# Valid time units are \"ns\", \"\
-    us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\n  igmpQueryInterval: \"125s\"\
-    \n\n# The network CIDRs of the interface on Node which is used for tunneling or\
-    \ routing the traffic across\n# Nodes. If there are multiple interfaces configured\
-    \ the same network CIDR, the first one is used. The\n# IP address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterfaceCIDRs:\n\n# Option antreaProxy contains AntreaProxy\
-    \ related configuration options.\nantreaProxy:\n  # ProxyAll tells antrea-agent\
-    \ to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP\
-    \ traffic,\n  # regardless of where they come from. Therefore, running kube-proxy\
-    \ is no longer required. This requires the AntreaProxy\n  # feature to be enabled.\n\
-    \  # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride\
-    \ must be used to access\n  # apiserver directly.\n  proxyAll: false\n  # A string\
-    \ array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values\
-    \ can be valid IP blocks.\n  # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string\
-    \ slice is meant to select all host IPv4/IPv6 addresses.\n  # Note that the option\
-    \ is only valid when proxyAll is true.\n  nodePortAddresses:\n  # An array of\
-    \ string values to specify a list of Services which should be ignored by AntreaProxy\
-    \ (traffic to these\n  # Services will not be load-balanced). Values can be a\
-    \ valid ClusterIP (e.g. 10.11.1.2) or a Service name\n  # with Namespace (e.g.\
-    \ kube-system/kube-dns)\n  skipServices:\n  # When ProxyLoadBalancerIPs is set\
-    \ to false, AntreaProxy no longer load-balances traffic destined to the\n  # External\
-    \ IPs of LoadBalancer Services. This is useful when the external LoadBalancer\
-    \ provides additional\n  # capabilities (e.g. TLS termination) and it is desirable\
-    \ for Pod-to-ExternalIP traffic to be sent to the\n  # external LoadBalancer instead\
-    \ of being load-balanced to an Endpoint directly by AntreaProxy.\n  # Note that\
-    \ setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll\
-    \ is set to true and\n  # kube-proxy is removed from the cluser, otherwise kube-proxy\
-    \ will still load-balance this traffic.\n  proxyLoadBalancerIPs: true\n\n# IPsec\
-    \ tunnel related configurations.\nipsec:\n  # The authentication mode of IPsec\
-    \ tunnel. It has the following options:\n  # - psk (default): Use pre-shared key\
-    \ (PSK) for IKE authentication.\n  # - cert:          Use CA-signed certificates\
-    \ for IKE authentication. This option requires the `IPsecCertAuth`\n  #      \
-    \            feature gate to be enabled.\n  authenticationMode: \"psk\"\n\nmulticluster:\n\
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.\n# This\
-    \ feature is supported only with encap mode.\n  enable: false\n# The Namespace\
-    \ where Antrea Multi-cluster Controller is running.\n# The default is antrea-agent's\
-    \ Namespace.\n  namespace: \"\"\n# Enable StretchedNetworkPolicy which could be\
-    \ enforced on cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n  enableStretchedNetworkPolicy: false\n"
-  antreaCNIConfig: "{\n    \"cniVersion\":\"0.3.0\",\n    \"name\": \"antrea\",\n\
-    \    \"plugins\": [\n        {\n            \"type\": \"antrea\",\n          \
-    \  \"ipam\": {\n                \"type\": \"host-local\"\n            }\n    \
-    \    }\n        ,\n        {\n            \"type\": \"portmap\",\n           \
-    \ \"capabilities\": {\"portMappings\": true}\n        }\n        ,\n        {\n\
-    \            \"type\": \"bandwidth\",\n            \"capabilities\": {\"bandwidth\"\
-    : true}\n        }\n    ]\n}\n"
-  antreaControllerConfig: "# FeatureGates is a map of feature names to bools that\
-    \ enable or disable experimental features.\nfeatureGates:\n# AllAlpha is a global\
-    \ toggle for alpha features. Per-feature key values override the default set by\
-    \ AllAlpha.\n#  AllAlpha: false\n\n# AllBeta is a global toggle for beta features.\
-    \ Per-feature key values override the default set by AllBeta.\n#  AllBeta: false\n\
-    \n# Enable traceflow which provides packet tracing feature to diagnose network\
-    \ issue.\n#  Traceflow: true\n\n# Enable Antrea ClusterNetworkPolicy feature to\
-    \ complement K8s NetworkPolicy for cluster admins\n# to define security policies\
-    \ which apply to the entire cluster, and Antrea NetworkPolicy\n# feature that\
-    \ supports priorities, rule actions and externalEntities in the future.\n#  AntreaPolicy:\
-    \ true\n\n# Enable collecting and exposing NetworkPolicy statistics.\n#  NetworkPolicyStats:\
-    \ true\n\n# Enable multicast traffic.\n#  Multicast: false\n\n# Enable controlling\
-    \ SNAT IPs of Pod egress traffic.\n#  Egress: true\n\n# Run Kubernetes NodeIPAMController\
-    \ with Antrea.\n#  NodeIPAM: false\n\n# Enable AntreaIPAM, which can allocate\
-    \ IP addresses from IPPools. AntreaIPAM is required by the\n# bridging mode and\
-    \ allocates IPs to Pods in bridging mode. It is also required to use Antrea for\n\
-    # IPAM when configuring secondary network interfaces with Multus.\n#  AntreaIPAM:\
-    \ false\n\n# Enable managing external IPs of Services of LoadBalancer type.\n\
-    #  ServiceExternalIP: false\n\n# Enable certificated-based authentication for\
-    \ IPsec.\n#  IPsecCertAuth: false\n\n# Enable managing ExternalNode for unmanaged\
-    \ VM/BM.\n#  ExternalNode: false\n\n# Enable collecting support bundle files with\
-    \ SupportBundleCollection CRD.\n#  SupportBundleCollection: false\n\n# Enable\
-    \ multi-cluster features.\n#  Multicluster: false\n\n# Enable users to protect\
-    \ their applications by specifying how they are allowed to communicate with others,\
-    \ taking\n# into account application context.\n#  L7NetworkPolicy: false\n\n#\
-    \ The port for the antrea-controller APIServer to serve on.\n# Note that if it's\
-    \ set to another value, the `containerPort` of the `api` port of the\n# `antrea-controller`\
-    \ container must be set to the same value.\napiPort: 10349\n\n# Enable metrics\
-    \ exposure via Prometheus. Initializes Prometheus metrics listener.\nenablePrometheusMetrics:\
-    \ true\n\n# Indicates whether to use auto-generated self-signed TLS certificate.\n\
-    # If false, a Secret named \"antrea-controller-tls\" must be provided with the\
-    \ following keys:\n#   ca.crt: <CA certificate>\n#   tls.crt: <TLS certificate>\n\
-    #   tls.key: <TLS private key>\nselfSignedCert: true\n\n# Comma-separated list\
-    \ of Cipher Suites. If omitted, the default Go Cipher Suites will be used.\n#\
-    \ https://golang.org/pkg/crypto/tls/#pkg-constants\n# Note that TLS1.3 Cipher\
-    \ Suites cannot be added to the list. But the apiserver will always\n# prefer\
-    \ TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites: \"\"\n\n# TLS min\
-    \ version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\ntlsMinVersion:\
-    \ \"\"\n\nnodeIPAM:\n  # Enable the integrated Node IPAM controller within the\
-    \ Antrea controller.\n  enableNodeIPAM: false\n  # CIDR ranges for Pods in cluster.\
-    \ String array containing single CIDR range, or multiple ranges.\n  # The CIDRs\
-    \ could be either IPv4 or IPv6. At most one CIDR may be specified for each IP\
-    \ family.\n  # Value ignored when enableNodeIPAM is false.\n  clusterCIDRs:\n\
-    \  # CIDR ranges for Services in cluster. It is not necessary to specify it when\
-    \ there is no overlap with clusterCIDRs.\n  # Value ignored when enableNodeIPAM\
-    \ is false.\n  serviceCIDR: \"\"\n  serviceCIDRv6: \"\"\n  # Mask size for IPv4\
-    \ Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is\
-    \ false\n  # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.\n\
-    \  nodeCIDRMaskSizeIPv4: 24\n  # Mask size for IPv6 Node CIDR in IPv6 or dual-stack\
-    \ cluster. Value ignored when enableNodeIPAM is false\n  # or when IPv6 Pod CIDR\
-    \ is not configured. Valid range is 64 to 126.\n  nodeCIDRMaskSizeIPv6: 64\n\n\
-    ipsecCSRSigner:\n  # Determines the auto-approve policy of Antrea CSR signer for\
-    \ IPsec certificates management.\n  # If enabled, Antrea will auto-approve the\
-    \ CertificateSingingRequest (CSR) if its subject and x509 extensions\n  # are\
-    \ permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume`\
-    \ feature is enabled,\n  # the Pod identity will also be validated to provide\
-    \ maximum security.\n  # If set to false, Antrea will not auto-approve CertificateSingingRequests\
-    \ and they need to be approved\n  # manually by `kubectl certificate approve`.\n\
-    \  autoApprove: true\n  # Indicates whether to use auto-generated self-signed\
-    \ CA certificate.\n  # If false, a Secret named \"antrea-ipsec-ca\" must be provided\
-    \ with the following keys:\n  #   tls.crt: <CA certificate>\n  #   tls.key: <CA\
-    \ private key>\n  selfSignedCA: true\n\nmulticluster:\n  # Enable StretchedNetworkPolicy\
-    \ which allow Antrea-native policies to select peers\n  # from other clusters\
-    \ in a ClusterSet.\n  enableStretchedNetworkPolicy: false\n"
-  antreaImage: antrea/antrea-ubi:v1.10.0
+  antreaAgentConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: true
+
+    # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # this flag will not take effect.
+    #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable NodePortLocal feature to make the Pods reachable externally through NodePort
+    #  NodePortLocal: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
+    #  FlowExporter: false
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable support for provisioning secondary network interfaces for Pods (using
+    # Pod annotations). At the moment, Antrea can only create secondary network
+    # interfaces using SR-IOV VFs on baremetal Nodes.
+    #  SecondaryNetwork: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable mirroring or redirecting the traffic Pods send or receive.
+    #  TrafficControl: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # Name of the OpenVSwitch bridge antrea-agent will create and use.
+    # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+    ovsBridge: "br-int"
+
+    # Datapath type to use for the OpenVSwitch bridge created by Antrea. At the moment, the only
+    # supported value is 'system', which corresponds to the kernel datapath.
+    #ovsDatapathType: system
+
+    # Name of the interface antrea-agent will create and use for host <--> pod communication.
+    # Make sure it doesn't conflict with your existing interfaces.
+    hostGateway: "antrea-gw0"
+
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to external network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: "encap"
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,
+    # this option will not take effect. Supported values:
+    # - geneve (default)
+    # - vxlan
+    # - gre
+    # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
+    tunnelType: "geneve"
+
+    # TunnelPort is the destination port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).
+    # If zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve, 4789 for VXLAN,
+    # and 7471 for STT.
+    tunnelPort: 0
+
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
+    # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
+    # It has the following options:
+    # - none (default):  Inter-node Pod traffic will not be encrypted.
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
+    #                    the PSK value must be passed to Antrea Agent through an environment
+    #                    variable: ANTREA_IPSEC_PSK.
+    # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
+    trafficEncryptionMode: "none"
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network, and forwarded/routed by the
+    # underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    enableBridgingMode: false
+
+    # Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the
+    # datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum.
+    # It affects Pods running on Linux Nodes only.
+    disableTXChecksumOffload: false
+
+    # Default MTU to use for the host gateway interface and the network interface of each Pod.
+    # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
+    # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
+    defaultMTU: 0
+
+    # wireGuard specifies WireGuard related configurations.
+    wireGuard:
+      # The port for WireGuard to receive traffic.
+      port: 51820
+
+    egress:
+      # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
+      exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
+
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
+    serviceCIDR: ""
+
+    # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
+    # cluster or an IPv6 only cluster. The value should be the same as the configuration for kube-apiserver specified by
+    # --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
+    # No default value for this field.
+    serviceCIDRv6: ""
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    apiPort: 10350
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+    # wrapped with []. When the collector is running in-cluster as a Service, set
+    # <HOST> to <Service namespace>/<Service name>. For example,
+    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+    # Flow Aggregator Service.
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+    # "udp" protocols. "tls" is used for securing communication between flow exporter and
+    # flow aggregator.
+    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
+
+    # Provide flow poll interval as a duration string. This determines how often the
+    # flow exporter dumps connections from the conntrack module. Flow poll interval
+    # should be greater than or equal to 1s (one second).
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    flowPollInterval: "5s"
+
+    # Provide the active flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for active flows. Thus, for flows with a continuous
+    # stream of packets, a flow record will be exported to the collector once the elapsed
+    # time since the last export event is equal to the value of this timeout.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    activeFlowExportTimeout: "5s"
+
+    # Provide the idle flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for idle flows. A flow is considered idle if no
+    # packet matching this flow has been observed since the last export event.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    idleFlowExportTimeout: "15s"
+
+    nodePortLocal:
+    # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
+    # enable this feature, you need to set "enable" to true, and ensure that the NodePortLocal feature
+    # gate is also enabled (which is the default).
+      enable: false
+    # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port
+    # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
+    # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
+    # directed to that port will be forwarded to the Pod.
+      portRange: "61000-62000"
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    kubeAPIServerOverride: ""
+
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The IP
+    # address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterface: ""
+
+    multicast:
+    # The names of the interfaces on Nodes that are used to forward multicast traffic.
+    # Defaults to transport interface if not set.
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
+
+    # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
+    # IP address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterfaceCIDRs:
+
+    # Option antreaProxy contains AntreaProxy related configuration options.
+    antreaProxy:
+      # ProxyAll tells antrea-agent to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP traffic,
+      # regardless of where they come from. Therefore, running kube-proxy is no longer required. This requires the AntreaProxy
+      # feature to be enabled.
+      # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
+      # apiserver directly.
+      proxyAll: false
+      # A string array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values can be valid IP blocks.
+      # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
+      # Note that the option is only valid when proxyAll is true.
+      nodePortAddresses:
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      skipServices:
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      proxyLoadBalancerIPs: true
+
+    # IPsec tunnel related configurations.
+    ipsec:
+      # The authentication mode of IPsec tunnel. It has the following options:
+      # - psk (default): Use pre-shared key (PSK) for IKE authentication.
+      # - cert:          Use CA-signed certificates for IKE authentication. This option requires the `IPsecCertAuth`
+      #                  feature gate to be enabled.
+      authenticationMode: "psk"
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enableGateway: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # The default is antrea-agent's Namespace.
+      namespace: ""
+    # Enable Multi-cluster NetworkPolicy (ingress rules).
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
+      enableStretchedNetworkPolicy: false
+    # Enable Pod to Pod connectivity.
+      enablePodToPodConnectivity: false
+  antreaCNIConfig: |
+    {
+        "cniVersion":"0.3.0",
+        "name": "antrea",
+        "plugins": [
+            {
+                "type": "antrea",
+                "ipam": {
+                    "type": "host-local"
+                }
+            }
+            ,
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true}
+            }
+            ,
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
+            }
+        ]
+    }
+  antreaControllerConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable managing ExternalNode for unmanaged VM/BM.
+    #  ExternalNode: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    apiPort: 10349
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, a Secret named "antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    selfSignedCert: true
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    nodeIPAM:
+      # Enable the integrated Node IPAM controller within the Antrea controller.
+      enableNodeIPAM: false
+      # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+      # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+      # Value ignored when enableNodeIPAM is false.
+      clusterCIDRs:
+      # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+      # Value ignored when enableNodeIPAM is false.
+      serviceCIDR: ""
+      serviceCIDRv6: ""
+      # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+      nodeCIDRMaskSizeIPv4: 24
+      # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+      nodeCIDRMaskSizeIPv6: 64
+
+    ipsecCSRSigner:
+      # Determines the auto-approve policy of Antrea CSR signer for IPsec certificates management.
+      # If enabled, Antrea will auto-approve the CertificateSingingRequest (CSR) if its subject and x509 extensions
+      # are permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume` feature is enabled,
+      # the Pod identity will also be validated to provide maximum security.
+      # If set to false, Antrea will not auto-approve CertificateSingingRequests and they need to be approved
+      # manually by `kubectl certificate approve`.
+      autoApprove: true
+      # Indicates whether to use auto-generated self-signed CA certificate.
+      # If false, a Secret named "antrea-ipsec-ca" must be provided with the following keys:
+      #   tls.crt: <CA certificate>
+      #   tls.key: <CA private key>
+      selfSignedCA: true
+
+    multicluster:
+      # Enable Multi-cluster NetworkPolicy.
+      enableStretchedNetworkPolicy: false
+  antreaImage: antrea/antrea-ubi:latest
   antreaPlatform: openshift
 

--- a/deploy/kubernetes/operator.antrea.vmware.com_v1_antreainstall_cr.yaml
+++ b/deploy/kubernetes/operator.antrea.vmware.com_v1_antreainstall_cr.yaml
@@ -4,284 +4,462 @@ metadata:
   name: antrea-install
   namespace: antrea-operator
 spec:
-  antreaAgentConfig: "# FeatureGates is a map of feature names to bools that enable\
-    \ or disable experimental features.\nfeatureGates:\n# AllAlpha is a global toggle\
-    \ for alpha features. Per-feature key values override the default set by AllAlpha.\n\
-    #  AllAlpha: false\n\n# AllBeta is a global toggle for beta features. Per-feature\
-    \ key values override the default set by AllBeta.\n#  AllBeta: false\n\n# Enable\
-    \ AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.\n\
-    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect\
-    \ on\n# Service traffic.\n#  AntreaProxy: true\n\n# Enable EndpointSlice support\
-    \ in AntreaProxy. Don't enable this feature unless that EndpointSlice\n# API version\
-    \ v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,\n\
-    # this flag will not take effect.\n#  EndpointSlice: false\n\n# Enable TopologyAwareHints\
-    \ in AntreaProxy. This requires AntreaProxy and EndpointSlice to be\n# enabled,\
-    \ otherwise this flag will not take effect.\n#  TopologyAwareHints: false\n\n\
-    # Enable traceflow which provides packet tracing feature to diagnose network issue.\n\
-    #  Traceflow: true\n\n# Enable NodePortLocal feature to make the Pods reachable\
-    \ externally through NodePort\n#  NodePortLocal: true\n\n# Enable Antrea ClusterNetworkPolicy\
-    \ feature to complement K8s NetworkPolicy for cluster admins\n# to define security\
-    \ policies which apply to the entire cluster, and Antrea NetworkPolicy\n# feature\
-    \ that supports priorities, rule actions and externalEntities in the future.\n\
-    #  AntreaPolicy: true\n\n# Enable flowexporter which exports polled conntrack\
-    \ connections as IPFIX flow records from each\n# agent to a configured collector.\n\
-    #  FlowExporter: false\n\n# Enable collecting and exposing NetworkPolicy statistics.\n\
-    #  NetworkPolicyStats: true\n\n# Enable controlling SNAT IPs of Pod egress traffic.\n\
-    #  Egress: true\n\n# Enable AntreaIPAM, which can allocate IP addresses from IPPools.\
-    \ AntreaIPAM is required by the\n# bridging mode and allocates IPs to Pods in\
-    \ bridging mode. It is also required to use Antrea for\n# IPAM when configuring\
-    \ secondary network interfaces with Multus.\n#  AntreaIPAM: false\n\n# Enable\
-    \ multicast traffic.\n#  Multicast: false\n\n# Enable Antrea Multi-cluster Gateway\
-    \ to support cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n#  Multicluster: false\n\n# Enable support for provisioning secondary\
-    \ network interfaces for Pods (using\n# Pod annotations). At the moment, Antrea\
-    \ can only create secondary network\n# interfaces using SR-IOV VFs on baremetal\
-    \ Nodes.\n#  SecondaryNetwork: false\n\n# Enable managing external IPs of Services\
-    \ of LoadBalancer type.\n#  ServiceExternalIP: false\n\n# Enable mirroring or\
-    \ redirecting the traffic Pods send or receive.\n#  TrafficControl: false\n\n\
-    # Enable certificated-based authentication for IPsec.\n#  IPsecCertAuth: false\n\
-    \n# Enable collecting support bundle files with SupportBundleCollection CRD.\n\
-    #  SupportBundleCollection: false\n\n# Enable users to protect their applications\
-    \ by specifying how they are allowed to communicate with others, taking\n# into\
-    \ account application context.\n#  L7NetworkPolicy: false\n\n# Name of the OpenVSwitch\
-    \ bridge antrea-agent will create and use.\n# Make sure it doesn't conflict with\
-    \ your existing OpenVSwitch bridges.\novsBridge: \"br-int\"\n\n# Datapath type\
-    \ to use for the OpenVSwitch bridge created by Antrea. At the moment, the only\n\
-    # supported value is 'system', which corresponds to the kernel datapath.\n#ovsDatapathType:\
-    \ system\n\n# Name of the interface antrea-agent will create and use for host\
-    \ <--> pod communication.\n# Make sure it doesn't conflict with your existing\
-    \ interfaces.\nhostGateway: \"antrea-gw0\"\n\n# Determines how traffic is encapsulated.\
-    \ It has the following options:\n# encap(default):    Inter-node Pod traffic is\
-    \ always encapsulated and Pod to external network\n#                    traffic\
-    \ is SNAT'd.\n# noEncap:           Inter-node Pod traffic is not encapsulated;\
-    \ Pod to external network traffic is\n#                    SNAT'd if noSNAT is\
-    \ not set to true. Underlying network must be capable of\n#                  \
-    \  supporting Pod traffic across IP subnets.\n# hybrid:            noEncap if\
-    \ source and destination Nodes are on the same subnet, otherwise encap.\n# networkPolicyOnly:\
-    \ Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates\
-    \ Pod\n#                    IPAM and connectivity to the primary CNI.\n#\ntrafficEncapMode:\
-    \ \"encap\"\n\n# Whether or not to SNAT (using the Node IP) the egress traffic\
-    \ from a Pod to the external network.\n# This option is for the noEncap traffic\
-    \ mode only, and the default value is false. In the noEncap\n# mode, if the cluster's\
-    \ Pod CIDR is reachable from the external network, then the Pod traffic to\n#\
-    \ the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent\
-    \ never\n# performs SNAT and this option will be ignored; for other modes it must\
-    \ be set to false.\nnoSNAT: false\n\n# Tunnel protocols used for encapsulating\
-    \ traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,\n# this\
-    \ option will not take effect. Supported values:\n# - geneve (default)\n# - vxlan\n\
-    # - gre\n# - stt\n# Note that \"gre\" is not supported for IPv6 clusters (IPv6-only\
-    \ or dual-stack clusters).\ntunnelType: \"geneve\"\n\n# TunnelPort is the destination\
-    \ port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).\n# If\
-    \ zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve,\
-    \ 4789 for VXLAN,\n# and 7471 for STT.\ntunnelPort: 0\n\n# TunnelCsum determines\
-    \ whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing\n\
-    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger\
-    \ GRO on the receiver for better\n# performance of Geneve and VXLAN tunnels. The\
-    \ issue has been fixed by\n# https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063,\
-    \ thus computing UDP checksum is\n# no longer necessary.\n# It should only be\
-    \ set to true when you are using an unpatched Linux kernel and observing poor\
-    \ transfer performance.\ntunnelCsum: false\n\n# Determines how tunnel traffic\
-    \ is encrypted. Currently encryption only works with encap mode.\n# It has the\
-    \ following options:\n# - none (default):  Inter-node Pod traffic will not be\
-    \ encrypted.\n# - ipsec:           Enable IPsec (ESP) encryption for Pod traffic\
-    \ across Nodes. Antrea uses\n#                    Preshared Key (PSK) for IKE\
-    \ authentication. When IPsec tunnel is enabled,\n#                    the PSK\
-    \ value must be passed to Antrea Agent through an environment\n#             \
-    \       variable: ANTREA_IPSEC_PSK.\n# - wireGuard:       Enable WireGuard for\
-    \ tunnel traffic encryption.\ntrafficEncryptionMode: \"none\"\n\n# Enable bridging\
-    \ mode of Pod network on Nodes, in which the Node's transport interface is connected\n\
-    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose\
-    \ IP addresses are\n# allocated by AntreaIPAM from IPPools) is sent to the underlay\
-    \ network, and forwarded/routed by the\n# underlay network.\n# This option requires\
-    \ the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only\n\
-    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,\n\
-    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.\nenableBridgingMode:\
-    \ false\n\n# Disable TX checksum offloading for container network interfaces.\
-    \ It's supposed to be set to true when the\n# datapath doesn't support TX checksum\
-    \ offloading, which causes packets to be dropped due to bad checksum.\n# It affects\
-    \ Pods running on Linux Nodes only.\ndisableTXChecksumOffload: false\n\n# Default\
-    \ MTU to use for the host gateway interface and the network interface of each\
-    \ Pod.\n# If omitted, antrea-agent will discover the MTU of the Node's primary\
-    \ interface and\n# also adjust MTU to accommodate for tunnel encapsulation overhead\
-    \ (if applicable).\ndefaultMTU: 0\n\n# wireGuard specifies WireGuard related configurations.\n\
-    wireGuard:\n  # The port for WireGuard to receive traffic.\n  port: 51820\n\n\
-    egress:\n  # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will\
-    \ not be SNAT'd by Egresses.\n  exceptCIDRs:\n\n# ClusterIP CIDR range for Services.\
-    \ It's required when AntreaProxy is not enabled, and should be\n# set to the same\
-    \ value as the one specified by --service-cluster-ip-range for kube-apiserver.\
-    \ When\n# AntreaProxy is enabled, this parameter is not needed and will be ignored\
-    \ if provided.\nserviceCIDR: \"\"\n\n# ClusterIP CIDR range for IPv6 Services.\
-    \ It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack\n\
-    # cluster or an IPv6 only cluster. The value should be the same as the configuration\
-    \ for kube-apiserver specified by\n# --service-cluster-ip-range. When AntreaProxy\
-    \ is enabled, this parameter is not needed.\n# No default value for this field.\n\
-    serviceCIDRv6: \"\"\n\n# The port for the antrea-agent APIServer to serve on.\n\
-    # Note that if it's set to another value, the `containerPort` of the `api` port\
-    \ of the\n# `antrea-agent` container must be set to the same value.\napiPort:\
-    \ 10350\n\n# Enable metrics exposure via Prometheus. Initializes Prometheus metrics\
-    \ listener.\nenablePrometheusMetrics: true\n\n# Provide the IPFIX collector address\
-    \ as a string with format <HOST>:[<PORT>][:<PROTO>].\n# HOST can either be the\
-    \ DNS name or the IP of the Flow Collector. For example,\n# \"flow-aggregator.flow-aggregator.svc\"\
-    \ can be provided as DNS name to connect\n# to the Antrea Flow Aggregator service.\
-    \ If IP, it can be either IPv4 or IPv6.\n# However, IPv6 address should be wrapped\
-    \ with [].\n# If PORT is empty, we default to 4739, the standard IPFIX port.\n\
-    # If no PROTO is given, we consider \"tls\" as default. We support \"tls\", \"\
-    tcp\" and\n# \"udp\" protocols. \"tls\" is used for securing communication between\
-    \ flow exporter and\n# flow aggregator.\nflowCollectorAddr: \"flow-aggregator.flow-aggregator.svc:4739:tls\"\
-    \n\n# Provide flow poll interval as a duration string. This determines how often\
-    \ the\n# flow exporter dumps connections from the conntrack module. Flow poll\
-    \ interval\n# should be greater than or equal to 1s (one second).\n# Valid time\
-    \ units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\nflowPollInterval:\
-    \ \"5s\"\n\n# Provide the active flow export timeout, which is the timeout after\
-    \ which a flow\n# record is sent to the collector for active flows. Thus, for\
-    \ flows with a continuous\n# stream of packets, a flow record will be exported\
-    \ to the collector once the elapsed\n# time since the last export event is equal\
-    \ to the value of this timeout.\n# Valid time units are \"ns\", \"us\" (or \"\xB5\
-    s\"), \"ms\", \"s\", \"m\", \"h\".\nactiveFlowExportTimeout: \"5s\"\n\n# Provide\
-    \ the idle flow export timeout, which is the timeout after which a flow\n# record\
-    \ is sent to the collector for idle flows. A flow is considered idle if no\n#\
-    \ packet matching this flow has been observed since the last export event.\n#\
-    \ Valid time units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"\
-    h\".\nidleFlowExportTimeout: \"15s\"\n\nnodePortLocal:\n# Enable NodePortLocal,\
-    \ a feature used to make Pods reachable using port forwarding on the host. To\n\
-    # enable this feature, you need to set \"enable\" to true, and ensure that the\
-    \ NodePortLocal feature\n# gate is also enabled (which is the default).\n  enable:\
-    \ false\n# Provide the port range used by NodePortLocal. When the NodePortLocal\
-    \ feature is enabled, a port\n# from that range will be assigned whenever a Pod's\
-    \ container defines a specific port to be exposed\n# (each container can define\
-    \ a list of ports as pod.spec.containers[].ports), and all Node traffic\n# directed\
-    \ to that port will be forwarded to the Pod.\n  portRange: \"61000-62000\"\n\n\
-    # Provide the address of Kubernetes apiserver, to override any value provided\
-    \ in kubeconfig or InClusterConfig.\n# Defaults to \"\". It must be a host string,\
-    \ a host:port pair, or a URL to the base of the apiserver.\nkubeAPIServerOverride:\
-    \ \"\"\n\n# Provide the address of DNS server, to override the kube-dns service.\
-    \ It's used to resolve hostname in FQDN policy.\n# Defaults to \"\". It must be\
-    \ a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,\n\
-    # [fd00:10:96::a]:53).\ndnsServerOverride: \"\"\n\n# Comma-separated list of Cipher\
-    \ Suites. If omitted, the default Go Cipher Suites will be used.\n# https://golang.org/pkg/crypto/tls/#pkg-constants\n\
-    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver\
-    \ will always\n# prefer TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites:\
-    \ \"\"\n\n# TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\n\
-    tlsMinVersion: \"\"\n\n# The name of the interface on Node which is used for tunneling\
-    \ or routing the traffic across Nodes.\n# If there are multiple IP addresses configured\
-    \ on the interface, the first one is used. The IP\n# address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterface: \"\"\n\nmulticast:\n# The names of the interfaces\
-    \ on Nodes that are used to forward multicast traffic.\n# Defaults to transport\
-    \ interface if not set.\n  multicastInterfaces:\n\n# The interval at which the\
-    \ antrea-agent sends IGMP queries to Pods.\n# Valid time units are \"ns\", \"\
-    us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\n  igmpQueryInterval: \"125s\"\
-    \n\n# The network CIDRs of the interface on Node which is used for tunneling or\
-    \ routing the traffic across\n# Nodes. If there are multiple interfaces configured\
-    \ the same network CIDR, the first one is used. The\n# IP address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterfaceCIDRs:\n\n# Option antreaProxy contains AntreaProxy\
-    \ related configuration options.\nantreaProxy:\n  # ProxyAll tells antrea-agent\
-    \ to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP\
-    \ traffic,\n  # regardless of where they come from. Therefore, running kube-proxy\
-    \ is no longer required. This requires the AntreaProxy\n  # feature to be enabled.\n\
-    \  # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride\
-    \ must be used to access\n  # apiserver directly.\n  proxyAll: false\n  # A string\
-    \ array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values\
-    \ can be valid IP blocks.\n  # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string\
-    \ slice is meant to select all host IPv4/IPv6 addresses.\n  # Note that the option\
-    \ is only valid when proxyAll is true.\n  nodePortAddresses:\n  # An array of\
-    \ string values to specify a list of Services which should be ignored by AntreaProxy\
-    \ (traffic to these\n  # Services will not be load-balanced). Values can be a\
-    \ valid ClusterIP (e.g. 10.11.1.2) or a Service name\n  # with Namespace (e.g.\
-    \ kube-system/kube-dns)\n  skipServices:\n  # When ProxyLoadBalancerIPs is set\
-    \ to false, AntreaProxy no longer load-balances traffic destined to the\n  # External\
-    \ IPs of LoadBalancer Services. This is useful when the external LoadBalancer\
-    \ provides additional\n  # capabilities (e.g. TLS termination) and it is desirable\
-    \ for Pod-to-ExternalIP traffic to be sent to the\n  # external LoadBalancer instead\
-    \ of being load-balanced to an Endpoint directly by AntreaProxy.\n  # Note that\
-    \ setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll\
-    \ is set to true and\n  # kube-proxy is removed from the cluser, otherwise kube-proxy\
-    \ will still load-balance this traffic.\n  proxyLoadBalancerIPs: true\n\n# IPsec\
-    \ tunnel related configurations.\nipsec:\n  # The authentication mode of IPsec\
-    \ tunnel. It has the following options:\n  # - psk (default): Use pre-shared key\
-    \ (PSK) for IKE authentication.\n  # - cert:          Use CA-signed certificates\
-    \ for IKE authentication. This option requires the `IPsecCertAuth`\n  #      \
-    \            feature gate to be enabled.\n  authenticationMode: \"psk\"\n\nmulticluster:\n\
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.\n# This\
-    \ feature is supported only with encap mode.\n  enable: false\n# The Namespace\
-    \ where Antrea Multi-cluster Controller is running.\n# The default is antrea-agent's\
-    \ Namespace.\n  namespace: \"\"\n# Enable StretchedNetworkPolicy which could be\
-    \ enforced on cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n  enableStretchedNetworkPolicy: false\n"
-  antreaCNIConfig: "{\n    \"cniVersion\":\"0.3.0\",\n    \"name\": \"antrea\",\n\
-    \    \"plugins\": [\n        {\n            \"type\": \"antrea\",\n          \
-    \  \"ipam\": {\n                \"type\": \"host-local\"\n            }\n    \
-    \    }\n        ,\n        {\n            \"type\": \"portmap\",\n           \
-    \ \"capabilities\": {\"portMappings\": true}\n        }\n        ,\n        {\n\
-    \            \"type\": \"bandwidth\",\n            \"capabilities\": {\"bandwidth\"\
-    : true}\n        }\n    ]\n}\n"
-  antreaControllerConfig: "# FeatureGates is a map of feature names to bools that\
-    \ enable or disable experimental features.\nfeatureGates:\n# AllAlpha is a global\
-    \ toggle for alpha features. Per-feature key values override the default set by\
-    \ AllAlpha.\n#  AllAlpha: false\n\n# AllBeta is a global toggle for beta features.\
-    \ Per-feature key values override the default set by AllBeta.\n#  AllBeta: false\n\
-    \n# Enable traceflow which provides packet tracing feature to diagnose network\
-    \ issue.\n#  Traceflow: true\n\n# Enable Antrea ClusterNetworkPolicy feature to\
-    \ complement K8s NetworkPolicy for cluster admins\n# to define security policies\
-    \ which apply to the entire cluster, and Antrea NetworkPolicy\n# feature that\
-    \ supports priorities, rule actions and externalEntities in the future.\n#  AntreaPolicy:\
-    \ true\n\n# Enable collecting and exposing NetworkPolicy statistics.\n#  NetworkPolicyStats:\
-    \ true\n\n# Enable multicast traffic.\n#  Multicast: false\n\n# Enable controlling\
-    \ SNAT IPs of Pod egress traffic.\n#  Egress: true\n\n# Run Kubernetes NodeIPAMController\
-    \ with Antrea.\n#  NodeIPAM: false\n\n# Enable AntreaIPAM, which can allocate\
-    \ IP addresses from IPPools. AntreaIPAM is required by the\n# bridging mode and\
-    \ allocates IPs to Pods in bridging mode. It is also required to use Antrea for\n\
-    # IPAM when configuring secondary network interfaces with Multus.\n#  AntreaIPAM:\
-    \ false\n\n# Enable managing external IPs of Services of LoadBalancer type.\n\
-    #  ServiceExternalIP: false\n\n# Enable certificated-based authentication for\
-    \ IPsec.\n#  IPsecCertAuth: false\n\n# Enable managing ExternalNode for unmanaged\
-    \ VM/BM.\n#  ExternalNode: false\n\n# Enable collecting support bundle files with\
-    \ SupportBundleCollection CRD.\n#  SupportBundleCollection: false\n\n# Enable\
-    \ multi-cluster features.\n#  Multicluster: false\n\n# Enable users to protect\
-    \ their applications by specifying how they are allowed to communicate with others,\
-    \ taking\n# into account application context.\n#  L7NetworkPolicy: false\n\n#\
-    \ The port for the antrea-controller APIServer to serve on.\n# Note that if it's\
-    \ set to another value, the `containerPort` of the `api` port of the\n# `antrea-controller`\
-    \ container must be set to the same value.\napiPort: 10349\n\n# Enable metrics\
-    \ exposure via Prometheus. Initializes Prometheus metrics listener.\nenablePrometheusMetrics:\
-    \ true\n\n# Indicates whether to use auto-generated self-signed TLS certificate.\n\
-    # If false, a Secret named \"antrea-controller-tls\" must be provided with the\
-    \ following keys:\n#   ca.crt: <CA certificate>\n#   tls.crt: <TLS certificate>\n\
-    #   tls.key: <TLS private key>\nselfSignedCert: true\n\n# Comma-separated list\
-    \ of Cipher Suites. If omitted, the default Go Cipher Suites will be used.\n#\
-    \ https://golang.org/pkg/crypto/tls/#pkg-constants\n# Note that TLS1.3 Cipher\
-    \ Suites cannot be added to the list. But the apiserver will always\n# prefer\
-    \ TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites: \"\"\n\n# TLS min\
-    \ version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\ntlsMinVersion:\
-    \ \"\"\n\nnodeIPAM:\n  # Enable the integrated Node IPAM controller within the\
-    \ Antrea controller.\n  enableNodeIPAM: false\n  # CIDR ranges for Pods in cluster.\
-    \ String array containing single CIDR range, or multiple ranges.\n  # The CIDRs\
-    \ could be either IPv4 or IPv6. At most one CIDR may be specified for each IP\
-    \ family.\n  # Value ignored when enableNodeIPAM is false.\n  clusterCIDRs:\n\
-    \  # CIDR ranges for Services in cluster. It is not necessary to specify it when\
-    \ there is no overlap with clusterCIDRs.\n  # Value ignored when enableNodeIPAM\
-    \ is false.\n  serviceCIDR: \"\"\n  serviceCIDRv6: \"\"\n  # Mask size for IPv4\
-    \ Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is\
-    \ false\n  # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.\n\
-    \  nodeCIDRMaskSizeIPv4: 24\n  # Mask size for IPv6 Node CIDR in IPv6 or dual-stack\
-    \ cluster. Value ignored when enableNodeIPAM is false\n  # or when IPv6 Pod CIDR\
-    \ is not configured. Valid range is 64 to 126.\n  nodeCIDRMaskSizeIPv6: 64\n\n\
-    ipsecCSRSigner:\n  # Determines the auto-approve policy of Antrea CSR signer for\
-    \ IPsec certificates management.\n  # If enabled, Antrea will auto-approve the\
-    \ CertificateSingingRequest (CSR) if its subject and x509 extensions\n  # are\
-    \ permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume`\
-    \ feature is enabled,\n  # the Pod identity will also be validated to provide\
-    \ maximum security.\n  # If set to false, Antrea will not auto-approve CertificateSingingRequests\
-    \ and they need to be approved\n  # manually by `kubectl certificate approve`.\n\
-    \  autoApprove: true\n  # Indicates whether to use auto-generated self-signed\
-    \ CA certificate.\n  # If false, a Secret named \"antrea-ipsec-ca\" must be provided\
-    \ with the following keys:\n  #   tls.crt: <CA certificate>\n  #   tls.key: <CA\
-    \ private key>\n  selfSignedCA: true\n\nmulticluster:\n  # Enable StretchedNetworkPolicy\
-    \ which allow Antrea-native policies to select peers\n  # from other clusters\
-    \ in a ClusterSet.\n  enableStretchedNetworkPolicy: false\n"
-  antreaImage: antrea/antrea-ubuntu:v1.10.0
+  antreaAgentConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: true
+
+    # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # this flag will not take effect.
+    #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable NodePortLocal feature to make the Pods reachable externally through NodePort
+    #  NodePortLocal: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
+    #  FlowExporter: false
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable support for provisioning secondary network interfaces for Pods (using
+    # Pod annotations). At the moment, Antrea can only create secondary network
+    # interfaces using SR-IOV VFs on baremetal Nodes.
+    #  SecondaryNetwork: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable mirroring or redirecting the traffic Pods send or receive.
+    #  TrafficControl: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # Name of the OpenVSwitch bridge antrea-agent will create and use.
+    # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+    ovsBridge: "br-int"
+
+    # Datapath type to use for the OpenVSwitch bridge created by Antrea. At the moment, the only
+    # supported value is 'system', which corresponds to the kernel datapath.
+    #ovsDatapathType: system
+
+    # Name of the interface antrea-agent will create and use for host <--> pod communication.
+    # Make sure it doesn't conflict with your existing interfaces.
+    hostGateway: "antrea-gw0"
+
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to external network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: "encap"
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,
+    # this option will not take effect. Supported values:
+    # - geneve (default)
+    # - vxlan
+    # - gre
+    # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
+    tunnelType: "geneve"
+
+    # TunnelPort is the destination port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).
+    # If zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve, 4789 for VXLAN,
+    # and 7471 for STT.
+    tunnelPort: 0
+
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
+    # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
+    # It has the following options:
+    # - none (default):  Inter-node Pod traffic will not be encrypted.
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
+    #                    the PSK value must be passed to Antrea Agent through an environment
+    #                    variable: ANTREA_IPSEC_PSK.
+    # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
+    trafficEncryptionMode: "none"
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network, and forwarded/routed by the
+    # underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    enableBridgingMode: false
+
+    # Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the
+    # datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum.
+    # It affects Pods running on Linux Nodes only.
+    disableTXChecksumOffload: false
+
+    # Default MTU to use for the host gateway interface and the network interface of each Pod.
+    # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
+    # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
+    defaultMTU: 0
+
+    # wireGuard specifies WireGuard related configurations.
+    wireGuard:
+      # The port for WireGuard to receive traffic.
+      port: 51820
+
+    egress:
+      # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
+      exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
+
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
+    serviceCIDR: ""
+
+    # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
+    # cluster or an IPv6 only cluster. The value should be the same as the configuration for kube-apiserver specified by
+    # --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
+    # No default value for this field.
+    serviceCIDRv6: ""
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    apiPort: 10350
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+    # wrapped with []. When the collector is running in-cluster as a Service, set
+    # <HOST> to <Service namespace>/<Service name>. For example,
+    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+    # Flow Aggregator Service.
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+    # "udp" protocols. "tls" is used for securing communication between flow exporter and
+    # flow aggregator.
+    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
+
+    # Provide flow poll interval as a duration string. This determines how often the
+    # flow exporter dumps connections from the conntrack module. Flow poll interval
+    # should be greater than or equal to 1s (one second).
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    flowPollInterval: "5s"
+
+    # Provide the active flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for active flows. Thus, for flows with a continuous
+    # stream of packets, a flow record will be exported to the collector once the elapsed
+    # time since the last export event is equal to the value of this timeout.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    activeFlowExportTimeout: "5s"
+
+    # Provide the idle flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for idle flows. A flow is considered idle if no
+    # packet matching this flow has been observed since the last export event.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    idleFlowExportTimeout: "15s"
+
+    nodePortLocal:
+    # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
+    # enable this feature, you need to set "enable" to true, and ensure that the NodePortLocal feature
+    # gate is also enabled (which is the default).
+      enable: false
+    # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port
+    # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
+    # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
+    # directed to that port will be forwarded to the Pod.
+      portRange: "61000-62000"
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    kubeAPIServerOverride: ""
+
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The IP
+    # address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterface: ""
+
+    multicast:
+    # The names of the interfaces on Nodes that are used to forward multicast traffic.
+    # Defaults to transport interface if not set.
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
+
+    # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
+    # IP address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterfaceCIDRs:
+
+    # Option antreaProxy contains AntreaProxy related configuration options.
+    antreaProxy:
+      # ProxyAll tells antrea-agent to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP traffic,
+      # regardless of where they come from. Therefore, running kube-proxy is no longer required. This requires the AntreaProxy
+      # feature to be enabled.
+      # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
+      # apiserver directly.
+      proxyAll: false
+      # A string array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values can be valid IP blocks.
+      # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
+      # Note that the option is only valid when proxyAll is true.
+      nodePortAddresses:
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      skipServices:
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      proxyLoadBalancerIPs: true
+
+    # IPsec tunnel related configurations.
+    ipsec:
+      # The authentication mode of IPsec tunnel. It has the following options:
+      # - psk (default): Use pre-shared key (PSK) for IKE authentication.
+      # - cert:          Use CA-signed certificates for IKE authentication. This option requires the `IPsecCertAuth`
+      #                  feature gate to be enabled.
+      authenticationMode: "psk"
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enableGateway: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # The default is antrea-agent's Namespace.
+      namespace: ""
+    # Enable Multi-cluster NetworkPolicy (ingress rules).
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
+      enableStretchedNetworkPolicy: false
+    # Enable Pod to Pod connectivity.
+      enablePodToPodConnectivity: false
+  antreaCNIConfig: |
+    {
+        "cniVersion":"0.3.0",
+        "name": "antrea",
+        "plugins": [
+            {
+                "type": "antrea",
+                "ipam": {
+                    "type": "host-local"
+                }
+            }
+            ,
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true}
+            }
+            ,
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
+            }
+        ]
+    }
+  antreaControllerConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable managing ExternalNode for unmanaged VM/BM.
+    #  ExternalNode: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    apiPort: 10349
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, a Secret named "antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    selfSignedCert: true
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    nodeIPAM:
+      # Enable the integrated Node IPAM controller within the Antrea controller.
+      enableNodeIPAM: false
+      # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+      # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+      # Value ignored when enableNodeIPAM is false.
+      clusterCIDRs:
+      # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+      # Value ignored when enableNodeIPAM is false.
+      serviceCIDR: ""
+      serviceCIDRv6: ""
+      # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+      nodeCIDRMaskSizeIPv4: 24
+      # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+      nodeCIDRMaskSizeIPv6: 64
+
+    ipsecCSRSigner:
+      # Determines the auto-approve policy of Antrea CSR signer for IPsec certificates management.
+      # If enabled, Antrea will auto-approve the CertificateSingingRequest (CSR) if its subject and x509 extensions
+      # are permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume` feature is enabled,
+      # the Pod identity will also be validated to provide maximum security.
+      # If set to false, Antrea will not auto-approve CertificateSingingRequests and they need to be approved
+      # manually by `kubectl certificate approve`.
+      autoApprove: true
+      # Indicates whether to use auto-generated self-signed CA certificate.
+      # If false, a Secret named "antrea-ipsec-ca" must be provided with the following keys:
+      #   tls.crt: <CA certificate>
+      #   tls.key: <CA private key>
+      selfSignedCA: true
+
+    multicluster:
+      # Enable Multi-cluster NetworkPolicy.
+      enableStretchedNetworkPolicy: false
+  antreaImage: antrea/antrea-ubuntu:latest
   antreaPlatform: kubernetes
 

--- a/deploy/openshift/operator.antrea.vmware.com_v1_antreainstall_cr.yaml
+++ b/deploy/openshift/operator.antrea.vmware.com_v1_antreainstall_cr.yaml
@@ -4,284 +4,462 @@ metadata:
   name: antrea-install
   namespace: antrea-operator
 spec:
-  antreaAgentConfig: "# FeatureGates is a map of feature names to bools that enable\
-    \ or disable experimental features.\nfeatureGates:\n# AllAlpha is a global toggle\
-    \ for alpha features. Per-feature key values override the default set by AllAlpha.\n\
-    #  AllAlpha: false\n\n# AllBeta is a global toggle for beta features. Per-feature\
-    \ key values override the default set by AllBeta.\n#  AllBeta: false\n\n# Enable\
-    \ AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.\n\
-    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect\
-    \ on\n# Service traffic.\n#  AntreaProxy: true\n\n# Enable EndpointSlice support\
-    \ in AntreaProxy. Don't enable this feature unless that EndpointSlice\n# API version\
-    \ v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,\n\
-    # this flag will not take effect.\n#  EndpointSlice: false\n\n# Enable TopologyAwareHints\
-    \ in AntreaProxy. This requires AntreaProxy and EndpointSlice to be\n# enabled,\
-    \ otherwise this flag will not take effect.\n#  TopologyAwareHints: false\n\n\
-    # Enable traceflow which provides packet tracing feature to diagnose network issue.\n\
-    #  Traceflow: true\n\n# Enable NodePortLocal feature to make the Pods reachable\
-    \ externally through NodePort\n#  NodePortLocal: true\n\n# Enable Antrea ClusterNetworkPolicy\
-    \ feature to complement K8s NetworkPolicy for cluster admins\n# to define security\
-    \ policies which apply to the entire cluster, and Antrea NetworkPolicy\n# feature\
-    \ that supports priorities, rule actions and externalEntities in the future.\n\
-    #  AntreaPolicy: true\n\n# Enable flowexporter which exports polled conntrack\
-    \ connections as IPFIX flow records from each\n# agent to a configured collector.\n\
-    #  FlowExporter: false\n\n# Enable collecting and exposing NetworkPolicy statistics.\n\
-    #  NetworkPolicyStats: true\n\n# Enable controlling SNAT IPs of Pod egress traffic.\n\
-    #  Egress: true\n\n# Enable AntreaIPAM, which can allocate IP addresses from IPPools.\
-    \ AntreaIPAM is required by the\n# bridging mode and allocates IPs to Pods in\
-    \ bridging mode. It is also required to use Antrea for\n# IPAM when configuring\
-    \ secondary network interfaces with Multus.\n#  AntreaIPAM: false\n\n# Enable\
-    \ multicast traffic.\n#  Multicast: false\n\n# Enable Antrea Multi-cluster Gateway\
-    \ to support cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n#  Multicluster: false\n\n# Enable support for provisioning secondary\
-    \ network interfaces for Pods (using\n# Pod annotations). At the moment, Antrea\
-    \ can only create secondary network\n# interfaces using SR-IOV VFs on baremetal\
-    \ Nodes.\n#  SecondaryNetwork: false\n\n# Enable managing external IPs of Services\
-    \ of LoadBalancer type.\n#  ServiceExternalIP: false\n\n# Enable mirroring or\
-    \ redirecting the traffic Pods send or receive.\n#  TrafficControl: false\n\n\
-    # Enable certificated-based authentication for IPsec.\n#  IPsecCertAuth: false\n\
-    \n# Enable collecting support bundle files with SupportBundleCollection CRD.\n\
-    #  SupportBundleCollection: false\n\n# Enable users to protect their applications\
-    \ by specifying how they are allowed to communicate with others, taking\n# into\
-    \ account application context.\n#  L7NetworkPolicy: false\n\n# Name of the OpenVSwitch\
-    \ bridge antrea-agent will create and use.\n# Make sure it doesn't conflict with\
-    \ your existing OpenVSwitch bridges.\novsBridge: \"br-int\"\n\n# Datapath type\
-    \ to use for the OpenVSwitch bridge created by Antrea. At the moment, the only\n\
-    # supported value is 'system', which corresponds to the kernel datapath.\n#ovsDatapathType:\
-    \ system\n\n# Name of the interface antrea-agent will create and use for host\
-    \ <--> pod communication.\n# Make sure it doesn't conflict with your existing\
-    \ interfaces.\nhostGateway: \"antrea-gw0\"\n\n# Determines how traffic is encapsulated.\
-    \ It has the following options:\n# encap(default):    Inter-node Pod traffic is\
-    \ always encapsulated and Pod to external network\n#                    traffic\
-    \ is SNAT'd.\n# noEncap:           Inter-node Pod traffic is not encapsulated;\
-    \ Pod to external network traffic is\n#                    SNAT'd if noSNAT is\
-    \ not set to true. Underlying network must be capable of\n#                  \
-    \  supporting Pod traffic across IP subnets.\n# hybrid:            noEncap if\
-    \ source and destination Nodes are on the same subnet, otherwise encap.\n# networkPolicyOnly:\
-    \ Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates\
-    \ Pod\n#                    IPAM and connectivity to the primary CNI.\n#\ntrafficEncapMode:\
-    \ \"encap\"\n\n# Whether or not to SNAT (using the Node IP) the egress traffic\
-    \ from a Pod to the external network.\n# This option is for the noEncap traffic\
-    \ mode only, and the default value is false. In the noEncap\n# mode, if the cluster's\
-    \ Pod CIDR is reachable from the external network, then the Pod traffic to\n#\
-    \ the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent\
-    \ never\n# performs SNAT and this option will be ignored; for other modes it must\
-    \ be set to false.\nnoSNAT: false\n\n# Tunnel protocols used for encapsulating\
-    \ traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,\n# this\
-    \ option will not take effect. Supported values:\n# - geneve (default)\n# - vxlan\n\
-    # - gre\n# - stt\n# Note that \"gre\" is not supported for IPv6 clusters (IPv6-only\
-    \ or dual-stack clusters).\ntunnelType: \"geneve\"\n\n# TunnelPort is the destination\
-    \ port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).\n# If\
-    \ zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve,\
-    \ 4789 for VXLAN,\n# and 7471 for STT.\ntunnelPort: 0\n\n# TunnelCsum determines\
-    \ whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing\n\
-    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger\
-    \ GRO on the receiver for better\n# performance of Geneve and VXLAN tunnels. The\
-    \ issue has been fixed by\n# https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063,\
-    \ thus computing UDP checksum is\n# no longer necessary.\n# It should only be\
-    \ set to true when you are using an unpatched Linux kernel and observing poor\
-    \ transfer performance.\ntunnelCsum: false\n\n# Determines how tunnel traffic\
-    \ is encrypted. Currently encryption only works with encap mode.\n# It has the\
-    \ following options:\n# - none (default):  Inter-node Pod traffic will not be\
-    \ encrypted.\n# - ipsec:           Enable IPsec (ESP) encryption for Pod traffic\
-    \ across Nodes. Antrea uses\n#                    Preshared Key (PSK) for IKE\
-    \ authentication. When IPsec tunnel is enabled,\n#                    the PSK\
-    \ value must be passed to Antrea Agent through an environment\n#             \
-    \       variable: ANTREA_IPSEC_PSK.\n# - wireGuard:       Enable WireGuard for\
-    \ tunnel traffic encryption.\ntrafficEncryptionMode: \"none\"\n\n# Enable bridging\
-    \ mode of Pod network on Nodes, in which the Node's transport interface is connected\n\
-    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose\
-    \ IP addresses are\n# allocated by AntreaIPAM from IPPools) is sent to the underlay\
-    \ network, and forwarded/routed by the\n# underlay network.\n# This option requires\
-    \ the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only\n\
-    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,\n\
-    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.\nenableBridgingMode:\
-    \ false\n\n# Disable TX checksum offloading for container network interfaces.\
-    \ It's supposed to be set to true when the\n# datapath doesn't support TX checksum\
-    \ offloading, which causes packets to be dropped due to bad checksum.\n# It affects\
-    \ Pods running on Linux Nodes only.\ndisableTXChecksumOffload: false\n\n# Default\
-    \ MTU to use for the host gateway interface and the network interface of each\
-    \ Pod.\n# If omitted, antrea-agent will discover the MTU of the Node's primary\
-    \ interface and\n# also adjust MTU to accommodate for tunnel encapsulation overhead\
-    \ (if applicable).\ndefaultMTU: 0\n\n# wireGuard specifies WireGuard related configurations.\n\
-    wireGuard:\n  # The port for WireGuard to receive traffic.\n  port: 51820\n\n\
-    egress:\n  # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will\
-    \ not be SNAT'd by Egresses.\n  exceptCIDRs:\n\n# ClusterIP CIDR range for Services.\
-    \ It's required when AntreaProxy is not enabled, and should be\n# set to the same\
-    \ value as the one specified by --service-cluster-ip-range for kube-apiserver.\
-    \ When\n# AntreaProxy is enabled, this parameter is not needed and will be ignored\
-    \ if provided.\nserviceCIDR: \"\"\n\n# ClusterIP CIDR range for IPv6 Services.\
-    \ It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack\n\
-    # cluster or an IPv6 only cluster. The value should be the same as the configuration\
-    \ for kube-apiserver specified by\n# --service-cluster-ip-range. When AntreaProxy\
-    \ is enabled, this parameter is not needed.\n# No default value for this field.\n\
-    serviceCIDRv6: \"\"\n\n# The port for the antrea-agent APIServer to serve on.\n\
-    # Note that if it's set to another value, the `containerPort` of the `api` port\
-    \ of the\n# `antrea-agent` container must be set to the same value.\napiPort:\
-    \ 10350\n\n# Enable metrics exposure via Prometheus. Initializes Prometheus metrics\
-    \ listener.\nenablePrometheusMetrics: true\n\n# Provide the IPFIX collector address\
-    \ as a string with format <HOST>:[<PORT>][:<PROTO>].\n# HOST can either be the\
-    \ DNS name or the IP of the Flow Collector. For example,\n# \"flow-aggregator.flow-aggregator.svc\"\
-    \ can be provided as DNS name to connect\n# to the Antrea Flow Aggregator service.\
-    \ If IP, it can be either IPv4 or IPv6.\n# However, IPv6 address should be wrapped\
-    \ with [].\n# If PORT is empty, we default to 4739, the standard IPFIX port.\n\
-    # If no PROTO is given, we consider \"tls\" as default. We support \"tls\", \"\
-    tcp\" and\n# \"udp\" protocols. \"tls\" is used for securing communication between\
-    \ flow exporter and\n# flow aggregator.\nflowCollectorAddr: \"flow-aggregator.flow-aggregator.svc:4739:tls\"\
-    \n\n# Provide flow poll interval as a duration string. This determines how often\
-    \ the\n# flow exporter dumps connections from the conntrack module. Flow poll\
-    \ interval\n# should be greater than or equal to 1s (one second).\n# Valid time\
-    \ units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\nflowPollInterval:\
-    \ \"5s\"\n\n# Provide the active flow export timeout, which is the timeout after\
-    \ which a flow\n# record is sent to the collector for active flows. Thus, for\
-    \ flows with a continuous\n# stream of packets, a flow record will be exported\
-    \ to the collector once the elapsed\n# time since the last export event is equal\
-    \ to the value of this timeout.\n# Valid time units are \"ns\", \"us\" (or \"\xB5\
-    s\"), \"ms\", \"s\", \"m\", \"h\".\nactiveFlowExportTimeout: \"5s\"\n\n# Provide\
-    \ the idle flow export timeout, which is the timeout after which a flow\n# record\
-    \ is sent to the collector for idle flows. A flow is considered idle if no\n#\
-    \ packet matching this flow has been observed since the last export event.\n#\
-    \ Valid time units are \"ns\", \"us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"\
-    h\".\nidleFlowExportTimeout: \"15s\"\n\nnodePortLocal:\n# Enable NodePortLocal,\
-    \ a feature used to make Pods reachable using port forwarding on the host. To\n\
-    # enable this feature, you need to set \"enable\" to true, and ensure that the\
-    \ NodePortLocal feature\n# gate is also enabled (which is the default).\n  enable:\
-    \ false\n# Provide the port range used by NodePortLocal. When the NodePortLocal\
-    \ feature is enabled, a port\n# from that range will be assigned whenever a Pod's\
-    \ container defines a specific port to be exposed\n# (each container can define\
-    \ a list of ports as pod.spec.containers[].ports), and all Node traffic\n# directed\
-    \ to that port will be forwarded to the Pod.\n  portRange: \"61000-62000\"\n\n\
-    # Provide the address of Kubernetes apiserver, to override any value provided\
-    \ in kubeconfig or InClusterConfig.\n# Defaults to \"\". It must be a host string,\
-    \ a host:port pair, or a URL to the base of the apiserver.\nkubeAPIServerOverride:\
-    \ \"\"\n\n# Provide the address of DNS server, to override the kube-dns service.\
-    \ It's used to resolve hostname in FQDN policy.\n# Defaults to \"\". It must be\
-    \ a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,\n\
-    # [fd00:10:96::a]:53).\ndnsServerOverride: \"\"\n\n# Comma-separated list of Cipher\
-    \ Suites. If omitted, the default Go Cipher Suites will be used.\n# https://golang.org/pkg/crypto/tls/#pkg-constants\n\
-    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver\
-    \ will always\n# prefer TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites:\
-    \ \"\"\n\n# TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\n\
-    tlsMinVersion: \"\"\n\n# The name of the interface on Node which is used for tunneling\
-    \ or routing the traffic across Nodes.\n# If there are multiple IP addresses configured\
-    \ on the interface, the first one is used. The IP\n# address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterface: \"\"\n\nmulticast:\n# The names of the interfaces\
-    \ on Nodes that are used to forward multicast traffic.\n# Defaults to transport\
-    \ interface if not set.\n  multicastInterfaces:\n\n# The interval at which the\
-    \ antrea-agent sends IGMP queries to Pods.\n# Valid time units are \"ns\", \"\
-    us\" (or \"\xB5s\"), \"ms\", \"s\", \"m\", \"h\".\n  igmpQueryInterval: \"125s\"\
-    \n\n# The network CIDRs of the interface on Node which is used for tunneling or\
-    \ routing the traffic across\n# Nodes. If there are multiple interfaces configured\
-    \ the same network CIDR, the first one is used. The\n# IP address used for tunneling\
-    \ or routing traffic to remote Nodes is decided in the following order of\n# preference\
-    \ (from highest to lowest):\n# 1. transportInterface\n# 2. transportInterfaceCIDRs\n\
-    # 3. The Node IP\ntransportInterfaceCIDRs:\n\n# Option antreaProxy contains AntreaProxy\
-    \ related configuration options.\nantreaProxy:\n  # ProxyAll tells antrea-agent\
-    \ to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP\
-    \ traffic,\n  # regardless of where they come from. Therefore, running kube-proxy\
-    \ is no longer required. This requires the AntreaProxy\n  # feature to be enabled.\n\
-    \  # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride\
-    \ must be used to access\n  # apiserver directly.\n  proxyAll: false\n  # A string\
-    \ array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values\
-    \ can be valid IP blocks.\n  # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string\
-    \ slice is meant to select all host IPv4/IPv6 addresses.\n  # Note that the option\
-    \ is only valid when proxyAll is true.\n  nodePortAddresses:\n  # An array of\
-    \ string values to specify a list of Services which should be ignored by AntreaProxy\
-    \ (traffic to these\n  # Services will not be load-balanced). Values can be a\
-    \ valid ClusterIP (e.g. 10.11.1.2) or a Service name\n  # with Namespace (e.g.\
-    \ kube-system/kube-dns)\n  skipServices:\n  # When ProxyLoadBalancerIPs is set\
-    \ to false, AntreaProxy no longer load-balances traffic destined to the\n  # External\
-    \ IPs of LoadBalancer Services. This is useful when the external LoadBalancer\
-    \ provides additional\n  # capabilities (e.g. TLS termination) and it is desirable\
-    \ for Pod-to-ExternalIP traffic to be sent to the\n  # external LoadBalancer instead\
-    \ of being load-balanced to an Endpoint directly by AntreaProxy.\n  # Note that\
-    \ setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll\
-    \ is set to true and\n  # kube-proxy is removed from the cluser, otherwise kube-proxy\
-    \ will still load-balance this traffic.\n  proxyLoadBalancerIPs: true\n\n# IPsec\
-    \ tunnel related configurations.\nipsec:\n  # The authentication mode of IPsec\
-    \ tunnel. It has the following options:\n  # - psk (default): Use pre-shared key\
-    \ (PSK) for IKE authentication.\n  # - cert:          Use CA-signed certificates\
-    \ for IKE authentication. This option requires the `IPsecCertAuth`\n  #      \
-    \            feature gate to be enabled.\n  authenticationMode: \"psk\"\n\nmulticluster:\n\
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.\n# This\
-    \ feature is supported only with encap mode.\n  enable: false\n# The Namespace\
-    \ where Antrea Multi-cluster Controller is running.\n# The default is antrea-agent's\
-    \ Namespace.\n  namespace: \"\"\n# Enable StretchedNetworkPolicy which could be\
-    \ enforced on cross-cluster traffic.\n# This feature is supported only with encap\
-    \ mode.\n  enableStretchedNetworkPolicy: false\n"
-  antreaCNIConfig: "{\n    \"cniVersion\":\"0.3.0\",\n    \"name\": \"antrea\",\n\
-    \    \"plugins\": [\n        {\n            \"type\": \"antrea\",\n          \
-    \  \"ipam\": {\n                \"type\": \"host-local\"\n            }\n    \
-    \    }\n        ,\n        {\n            \"type\": \"portmap\",\n           \
-    \ \"capabilities\": {\"portMappings\": true}\n        }\n        ,\n        {\n\
-    \            \"type\": \"bandwidth\",\n            \"capabilities\": {\"bandwidth\"\
-    : true}\n        }\n    ]\n}\n"
-  antreaControllerConfig: "# FeatureGates is a map of feature names to bools that\
-    \ enable or disable experimental features.\nfeatureGates:\n# AllAlpha is a global\
-    \ toggle for alpha features. Per-feature key values override the default set by\
-    \ AllAlpha.\n#  AllAlpha: false\n\n# AllBeta is a global toggle for beta features.\
-    \ Per-feature key values override the default set by AllBeta.\n#  AllBeta: false\n\
-    \n# Enable traceflow which provides packet tracing feature to diagnose network\
-    \ issue.\n#  Traceflow: true\n\n# Enable Antrea ClusterNetworkPolicy feature to\
-    \ complement K8s NetworkPolicy for cluster admins\n# to define security policies\
-    \ which apply to the entire cluster, and Antrea NetworkPolicy\n# feature that\
-    \ supports priorities, rule actions and externalEntities in the future.\n#  AntreaPolicy:\
-    \ true\n\n# Enable collecting and exposing NetworkPolicy statistics.\n#  NetworkPolicyStats:\
-    \ true\n\n# Enable multicast traffic.\n#  Multicast: false\n\n# Enable controlling\
-    \ SNAT IPs of Pod egress traffic.\n#  Egress: true\n\n# Run Kubernetes NodeIPAMController\
-    \ with Antrea.\n#  NodeIPAM: false\n\n# Enable AntreaIPAM, which can allocate\
-    \ IP addresses from IPPools. AntreaIPAM is required by the\n# bridging mode and\
-    \ allocates IPs to Pods in bridging mode. It is also required to use Antrea for\n\
-    # IPAM when configuring secondary network interfaces with Multus.\n#  AntreaIPAM:\
-    \ false\n\n# Enable managing external IPs of Services of LoadBalancer type.\n\
-    #  ServiceExternalIP: false\n\n# Enable certificated-based authentication for\
-    \ IPsec.\n#  IPsecCertAuth: false\n\n# Enable managing ExternalNode for unmanaged\
-    \ VM/BM.\n#  ExternalNode: false\n\n# Enable collecting support bundle files with\
-    \ SupportBundleCollection CRD.\n#  SupportBundleCollection: false\n\n# Enable\
-    \ multi-cluster features.\n#  Multicluster: false\n\n# Enable users to protect\
-    \ their applications by specifying how they are allowed to communicate with others,\
-    \ taking\n# into account application context.\n#  L7NetworkPolicy: false\n\n#\
-    \ The port for the antrea-controller APIServer to serve on.\n# Note that if it's\
-    \ set to another value, the `containerPort` of the `api` port of the\n# `antrea-controller`\
-    \ container must be set to the same value.\napiPort: 10349\n\n# Enable metrics\
-    \ exposure via Prometheus. Initializes Prometheus metrics listener.\nenablePrometheusMetrics:\
-    \ true\n\n# Indicates whether to use auto-generated self-signed TLS certificate.\n\
-    # If false, a Secret named \"antrea-controller-tls\" must be provided with the\
-    \ following keys:\n#   ca.crt: <CA certificate>\n#   tls.crt: <TLS certificate>\n\
-    #   tls.key: <TLS private key>\nselfSignedCert: true\n\n# Comma-separated list\
-    \ of Cipher Suites. If omitted, the default Go Cipher Suites will be used.\n#\
-    \ https://golang.org/pkg/crypto/tls/#pkg-constants\n# Note that TLS1.3 Cipher\
-    \ Suites cannot be added to the list. But the apiserver will always\n# prefer\
-    \ TLS1.3 Cipher Suites whenever possible.\ntlsCipherSuites: \"\"\n\n# TLS min\
-    \ version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\ntlsMinVersion:\
-    \ \"\"\n\nnodeIPAM:\n  # Enable the integrated Node IPAM controller within the\
-    \ Antrea controller.\n  enableNodeIPAM: false\n  # CIDR ranges for Pods in cluster.\
-    \ String array containing single CIDR range, or multiple ranges.\n  # The CIDRs\
-    \ could be either IPv4 or IPv6. At most one CIDR may be specified for each IP\
-    \ family.\n  # Value ignored when enableNodeIPAM is false.\n  clusterCIDRs:\n\
-    \  # CIDR ranges for Services in cluster. It is not necessary to specify it when\
-    \ there is no overlap with clusterCIDRs.\n  # Value ignored when enableNodeIPAM\
-    \ is false.\n  serviceCIDR: \"\"\n  serviceCIDRv6: \"\"\n  # Mask size for IPv4\
-    \ Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is\
-    \ false\n  # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.\n\
-    \  nodeCIDRMaskSizeIPv4: 24\n  # Mask size for IPv6 Node CIDR in IPv6 or dual-stack\
-    \ cluster. Value ignored when enableNodeIPAM is false\n  # or when IPv6 Pod CIDR\
-    \ is not configured. Valid range is 64 to 126.\n  nodeCIDRMaskSizeIPv6: 64\n\n\
-    ipsecCSRSigner:\n  # Determines the auto-approve policy of Antrea CSR signer for\
-    \ IPsec certificates management.\n  # If enabled, Antrea will auto-approve the\
-    \ CertificateSingingRequest (CSR) if its subject and x509 extensions\n  # are\
-    \ permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume`\
-    \ feature is enabled,\n  # the Pod identity will also be validated to provide\
-    \ maximum security.\n  # If set to false, Antrea will not auto-approve CertificateSingingRequests\
-    \ and they need to be approved\n  # manually by `kubectl certificate approve`.\n\
-    \  autoApprove: true\n  # Indicates whether to use auto-generated self-signed\
-    \ CA certificate.\n  # If false, a Secret named \"antrea-ipsec-ca\" must be provided\
-    \ with the following keys:\n  #   tls.crt: <CA certificate>\n  #   tls.key: <CA\
-    \ private key>\n  selfSignedCA: true\n\nmulticluster:\n  # Enable StretchedNetworkPolicy\
-    \ which allow Antrea-native policies to select peers\n  # from other clusters\
-    \ in a ClusterSet.\n  enableStretchedNetworkPolicy: false\n"
-  antreaImage: antrea/antrea-ubi:v1.10.0
+  antreaAgentConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
+    # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
+    # Service traffic.
+    #  AntreaProxy: true
+
+    # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # this flag will not take effect.
+    #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable NodePortLocal feature to make the Pods reachable externally through NodePort
+    #  NodePortLocal: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable flowexporter which exports polled conntrack connections as IPFIX flow records from each
+    # agent to a configured collector.
+    #  FlowExporter: false
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable support for provisioning secondary network interfaces for Pods (using
+    # Pod annotations). At the moment, Antrea can only create secondary network
+    # interfaces using SR-IOV VFs on baremetal Nodes.
+    #  SecondaryNetwork: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable mirroring or redirecting the traffic Pods send or receive.
+    #  TrafficControl: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # Name of the OpenVSwitch bridge antrea-agent will create and use.
+    # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+    ovsBridge: "br-int"
+
+    # Datapath type to use for the OpenVSwitch bridge created by Antrea. At the moment, the only
+    # supported value is 'system', which corresponds to the kernel datapath.
+    #ovsDatapathType: system
+
+    # Name of the interface antrea-agent will create and use for host <--> pod communication.
+    # Make sure it doesn't conflict with your existing interfaces.
+    hostGateway: "antrea-gw0"
+
+    # Determines how traffic is encapsulated. It has the following options:
+    # encap(default):    Inter-node Pod traffic is always encapsulated and Pod to external network
+    #                    traffic is SNAT'd.
+    # noEncap:           Inter-node Pod traffic is not encapsulated; Pod to external network traffic is
+    #                    SNAT'd if noSNAT is not set to true. Underlying network must be capable of
+    #                    supporting Pod traffic across IP subnets.
+    # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
+    # networkPolicyOnly: Antrea enforces NetworkPolicy only, and utilizes CNI chaining and delegates Pod
+    #                    IPAM and connectivity to the primary CNI.
+    #
+    trafficEncapMode: "encap"
+
+    # Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network.
+    # This option is for the noEncap traffic mode only, and the default value is false. In the noEncap
+    # mode, if the cluster's Pod CIDR is reachable from the external network, then the Pod traffic to
+    # the external network needs not be SNAT'd. In the networkPolicyOnly mode, antrea-agent never
+    # performs SNAT and this option will be ignored; for other modes it must be set to false.
+    noSNAT: false
+
+    # Tunnel protocols used for encapsulating traffic across Nodes. If WireGuard is enabled in trafficEncryptionMode,
+    # this option will not take effect. Supported values:
+    # - geneve (default)
+    # - vxlan
+    # - gre
+    # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
+    tunnelType: "geneve"
+
+    # TunnelPort is the destination port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT).
+    # If zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve, 4789 for VXLAN,
+    # and 7471 for STT.
+    tunnelPort: 0
+
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
+    # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
+    # It has the following options:
+    # - none (default):  Inter-node Pod traffic will not be encrypted.
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
+    #                    the PSK value must be passed to Antrea Agent through an environment
+    #                    variable: ANTREA_IPSEC_PSK.
+    # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
+    trafficEncryptionMode: "none"
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic of AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network, and forwarded/routed by the
+    # underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    enableBridgingMode: false
+
+    # Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the
+    # datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum.
+    # It affects Pods running on Linux Nodes only.
+    disableTXChecksumOffload: false
+
+    # Default MTU to use for the host gateway interface and the network interface of each Pod.
+    # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
+    # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
+    defaultMTU: 0
+
+    # wireGuard specifies WireGuard related configurations.
+    wireGuard:
+      # The port for WireGuard to receive traffic.
+      port: 51820
+
+    egress:
+      # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
+      exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
+
+    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
+    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
+    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
+    serviceCIDR: ""
+
+    # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
+    # cluster or an IPv6 only cluster. The value should be the same as the configuration for kube-apiserver specified by
+    # --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
+    # No default value for this field.
+    serviceCIDRv6: ""
+
+    # The port for the antrea-agent APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-agent` container must be set to the same value.
+    apiPort: 10350
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+    # wrapped with []. When the collector is running in-cluster as a Service, set
+    # <HOST> to <Service namespace>/<Service name>. For example,
+    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+    # Flow Aggregator Service.
+    # If PORT is empty, we default to 4739, the standard IPFIX port.
+    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+    # "udp" protocols. "tls" is used for securing communication between flow exporter and
+    # flow aggregator.
+    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
+
+    # Provide flow poll interval as a duration string. This determines how often the
+    # flow exporter dumps connections from the conntrack module. Flow poll interval
+    # should be greater than or equal to 1s (one second).
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    flowPollInterval: "5s"
+
+    # Provide the active flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for active flows. Thus, for flows with a continuous
+    # stream of packets, a flow record will be exported to the collector once the elapsed
+    # time since the last export event is equal to the value of this timeout.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    activeFlowExportTimeout: "5s"
+
+    # Provide the idle flow export timeout, which is the timeout after which a flow
+    # record is sent to the collector for idle flows. A flow is considered idle if no
+    # packet matching this flow has been observed since the last export event.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    idleFlowExportTimeout: "15s"
+
+    nodePortLocal:
+    # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
+    # enable this feature, you need to set "enable" to true, and ensure that the NodePortLocal feature
+    # gate is also enabled (which is the default).
+      enable: false
+    # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port
+    # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
+    # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
+    # directed to that port will be forwarded to the Pod.
+      portRange: "61000-62000"
+
+    # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
+    # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
+    kubeAPIServerOverride: ""
+
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The IP
+    # address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterface: ""
+
+    multicast:
+    # The names of the interfaces on Nodes that are used to forward multicast traffic.
+    # Defaults to transport interface if not set.
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
+
+    # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
+    # IP address used for tunneling or routing traffic to remote Nodes is decided in the following order of
+    # preference (from highest to lowest):
+    # 1. transportInterface
+    # 2. transportInterfaceCIDRs
+    # 3. The Node IP
+    transportInterfaceCIDRs:
+
+    # Option antreaProxy contains AntreaProxy related configuration options.
+    antreaProxy:
+      # ProxyAll tells antrea-agent to proxy all Service traffic, including NodePort, LoadBalancer, and ClusterIP traffic,
+      # regardless of where they come from. Therefore, running kube-proxy is no longer required. This requires the AntreaProxy
+      # feature to be enabled.
+      # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
+      # apiserver directly.
+      proxyAll: false
+      # A string array of values which specifies the host IPv4/IPv6 addresses for NodePort. Values can be valid IP blocks.
+      # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
+      # Note that the option is only valid when proxyAll is true.
+      nodePortAddresses:
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      skipServices:
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      proxyLoadBalancerIPs: true
+
+    # IPsec tunnel related configurations.
+    ipsec:
+      # The authentication mode of IPsec tunnel. It has the following options:
+      # - psk (default): Use pre-shared key (PSK) for IKE authentication.
+      # - cert:          Use CA-signed certificates for IKE authentication. This option requires the `IPsecCertAuth`
+      #                  feature gate to be enabled.
+      authenticationMode: "psk"
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enableGateway: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # The default is antrea-agent's Namespace.
+      namespace: ""
+    # Enable Multi-cluster NetworkPolicy (ingress rules).
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
+      enableStretchedNetworkPolicy: false
+    # Enable Pod to Pod connectivity.
+      enablePodToPodConnectivity: false
+  antreaCNIConfig: |
+    {
+        "cniVersion":"0.3.0",
+        "name": "antrea",
+        "plugins": [
+            {
+                "type": "antrea",
+                "ipam": {
+                    "type": "host-local"
+                }
+            }
+            ,
+            {
+                "type": "portmap",
+                "capabilities": {"portMappings": true}
+            }
+            ,
+            {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
+            }
+        ]
+    }
+  antreaControllerConfig: |
+    # FeatureGates is a map of feature names to bools that enable or disable experimental features.
+    featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
+    # Enable traceflow which provides packet tracing feature to diagnose network issue.
+    #  Traceflow: true
+
+    # Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+    # to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+    # feature that supports priorities, rule actions and externalEntities in the future.
+    #  AntreaPolicy: true
+
+    # Enable collecting and exposing NetworkPolicy statistics.
+    #  NetworkPolicyStats: true
+
+    # Enable multicast traffic.
+    #  Multicast: false
+
+    # Enable controlling SNAT IPs of Pod egress traffic.
+    #  Egress: true
+
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
+    # IPAM when configuring secondary network interfaces with Multus.
+    #  AntreaIPAM: false
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
+    # Enable certificated-based authentication for IPsec.
+    #  IPsecCertAuth: false
+
+    # Enable managing ExternalNode for unmanaged VM/BM.
+    #  ExternalNode: false
+
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
+    # Enable Antrea Multi-cluster features.
+    #  Multicluster: false
+
+    # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
+    # into account application context.
+    #  L7NetworkPolicy: false
+
+    # The port for the antrea-controller APIServer to serve on.
+    # Note that if it's set to another value, the `containerPort` of the `api` port of the
+    # `antrea-controller` container must be set to the same value.
+    apiPort: 10349
+
+    # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
+    enablePrometheusMetrics: true
+
+    # Indicates whether to use auto-generated self-signed TLS certificate.
+    # If false, a Secret named "antrea-controller-tls" must be provided with the following keys:
+    #   ca.crt: <CA certificate>
+    #   tls.crt: <TLS certificate>
+    #   tls.key: <TLS private key>
+    selfSignedCert: true
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    tlsCipherSuites: ""
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    tlsMinVersion: ""
+
+    nodeIPAM:
+      # Enable the integrated Node IPAM controller within the Antrea controller.
+      enableNodeIPAM: false
+      # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+      # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+      # Value ignored when enableNodeIPAM is false.
+      clusterCIDRs:
+      # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+      # Value ignored when enableNodeIPAM is false.
+      serviceCIDR: ""
+      serviceCIDRv6: ""
+      # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+      nodeCIDRMaskSizeIPv4: 24
+      # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+      # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+      nodeCIDRMaskSizeIPv6: 64
+
+    ipsecCSRSigner:
+      # Determines the auto-approve policy of Antrea CSR signer for IPsec certificates management.
+      # If enabled, Antrea will auto-approve the CertificateSingingRequest (CSR) if its subject and x509 extensions
+      # are permitted, and the requestor can be validated. If K8s `BoundServiceAccountTokenVolume` feature is enabled,
+      # the Pod identity will also be validated to provide maximum security.
+      # If set to false, Antrea will not auto-approve CertificateSingingRequests and they need to be approved
+      # manually by `kubectl certificate approve`.
+      autoApprove: true
+      # Indicates whether to use auto-generated self-signed CA certificate.
+      # If false, a Secret named "antrea-ipsec-ca" must be provided with the following keys:
+      #   tls.crt: <CA certificate>
+      #   tls.key: <CA private key>
+      selfSignedCA: true
+
+    multicluster:
+      # Enable Multi-cluster NetworkPolicy.
+      enableStretchedNetworkPolicy: false
+  antreaImage: antrea/antrea-ubi:latest
   antreaPlatform: openshift
 

--- a/hack/generate-antrea-samples.py
+++ b/hack/generate-antrea-samples.py
@@ -54,6 +54,6 @@ for f in args.yaml_files:
             out['spec']['antreaCNIConfig'] = doc.get('data', {}).get('antrea-cni.conflist', "")
             out['spec']['antreaControllerConfig'] = doc.get('data', {}).get('antrea-controller.conf', "")
 
-print(yaml.dump(out))
+print(yaml.dump(out, default_flow_style=False, allow_unicode=True))
 
 exit(0)


### PR DESCRIPTION
By default, PyYAML chooses the style of a collection depending on whether it has nested collections. If collections are always serialized in the block style, set the parameter default_flow_style of dump() to False. And set allow_unicode to True as there are some special character like `µs` in antrea-config. Also, generate antrea resources according to latest commit on main branch of Antrea.