### PR TITLE
Install Golang 1.19 for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build antrea-operator Docker image
         run: make docker-build
       - name: Build antrea-operator-bundle Docker image

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -22,7 +22,11 @@ jobs:
     runs-on: [ubuntu-latest]
     needs: get-version
     steps:
-      - uses: actions/checkout@v2
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v4
       - name: Build antrea-operator Docker image
         env:
           VERSION: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -16,7 +16,7 @@ jobs:
   validate_image:
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run container certification
         env:
           VERSION: ${{ github.event.inputs.version_tag }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Set up Go 1.19
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Check-out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build antrea-operator binary
         run: make bin
       - name: Run tests
@@ -26,10 +26,10 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Set up Go 1.19
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Check-out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check tidy
         run: make test-tidy

--- a/.github/workflows/validate_imports.yml
+++ b/.github/workflows/validate_imports.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'vmware/antrea-operator-for-kubernetes'
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate antrea-manifest/antrea.yml
         run: |
           TMP_MANIFEST=$(mktemp /tmp/antrea.yml.XXXXXXX)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@ COPY version/ version/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-
+FROM golang:1.19.10 as golang-build
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL name="antrea-operator-for-kubernetes"


### PR DESCRIPTION
Starting with Go 1.21, the runtime system needs to have a version of glibc "compatible" with the version available at build time. The ubi8 image comes with a very old version of glibc compared to the golang builder. so, the Antrea Operator binaries will fail to run and hit GLIBC issue.

To fix this issue, we need to install Golang manually in ubi8 image when making docker build. Moreover, we use Golang 1.19 for Github workflow build action. To align this workflow, we install Golang 1.19 for Github workflow build tag action and Docker image build.