### PR TITLE
Certify v1.14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build antrea-operator Docker image
         run: make docker-build
       - name: Build antrea-operator-bundle Docker image

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -17,12 +17,12 @@ jobs:
           TAG: ${{ github.ref }}
         run: |
           version=${TAG:10}
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
   build:
     runs-on: [ubuntu-latest]
     needs: get-version
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build antrea-operator Docker image
         env:
           VERSION: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -16,7 +16,7 @@ jobs:
   validate_image:
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run container certification
         env:
           VERSION: ${{ github.event.inputs.version_tag }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Set up Go 1.19
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Check-out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build antrea-operator binary
         run: make bin
       - name: Run tests
@@ -26,10 +26,10 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Set up Go 1.19
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Check-out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check tidy
         run: make test-tidy

--- a/.github/workflows/validate_imports.yml
+++ b/.github/workflows/validate_imports.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'vmware/antrea-operator-for-kubernetes'
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate antrea-manifest/antrea.yml
         run: |
           TMP_MANIFEST=$(mktemp /tmp/antrea.yml.XXXXXXX)

--- a/bundle/manifests/antrea-operator-for-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/antrea-operator-for-kubernetes.clusterserviceversion.yaml
@@ -21,9 +21,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-05T09:04:20Z"
-    description: An operator which installs Antrea network CNI plugin on the Kubernetes
-      cluster.
+    createdAt: "2023-12-06T09:58:08Z"
+    description: An operator which installs Antrea network CNI plugin on the Kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: antrea-operator-for-kubernetes.v1.14.1
@@ -32,383 +31,384 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: AntreaInstall is the Schema for the antreainstalls API
-      displayName: Antrea Install
-      kind: AntreaInstall
-      name: antreainstalls.operator.antrea.vmware.com
-      resources:
-      - kind: Deployment
-        name: A Kubernetes Deployment for the Operator
+      - description: AntreaInstall is the Schema for the antreainstalls API
+        displayName: Antrea Install
+        kind: AntreaInstall
+        name: antreainstalls.operator.antrea.vmware.com
+        resources:
+          - kind: Deployment
+            name: A Kubernetes Deployment for the Operator
+            version: v1
+          - kind: Network
+            name: Openshift's cluster network
+            version: v1
+          - kind: ClusterOperator
+            name: antrea cluster operator
+            version: v1
+          - kind: AntreaInstall
+            name: this operator's CR
+            version: v1
+        specDescriptors:
+          - description: AntreaAgentConfig holds the configurations for antrea-agent.
+            displayName: Antrea Agent Config
+            path: antreaAgentConfig
+          - description: AntreaCNIConfig holds the configuration of CNI.
+            displayName: Antrea CNIConfig
+            path: antreaCNIConfig
+          - description: AntreaControllerConfig holds the configurations for antrea-controller.
+            displayName: Antrea Controller Config
+            path: antreaControllerConfig
+          - description: AntreaImage is the Docker image name used by antrea-agent and antrea-controller.
+            displayName: Antrea Image
+            path: antreaImage
+          - description: AntreaPlatform is the platform on which antrea will be deployed.
+            displayName: Antrea Platform
+            path: antreaPlatform
+        statusDescriptors:
+          - description: Conditions describes the state of Antrea installation.
+            displayName: Conditions
+            path: conditions
         version: v1
-      - kind: Network
-        name: Openshift's cluster network
-        version: v1
-      - kind: ClusterOperator
-        name: antrea cluster operator
-        version: v1
-      - kind: AntreaInstall
-        name: this operator's CR
-        version: v1
-      specDescriptors:
-      - description: AntreaAgentConfig holds the configurations for antrea-agent.
-        displayName: Antrea Agent Config
-        path: antreaAgentConfig
-      - description: AntreaCNIConfig holds the configuration of CNI.
-        displayName: Antrea CNIConfig
-        path: antreaCNIConfig
-      - description: AntreaControllerConfig holds the configurations for antrea-controller.
-        displayName: Antrea Controller Config
-        path: antreaControllerConfig
-      - description: AntreaImage is the Docker image name used by antrea-agent and
-          antrea-controller.
-        displayName: Antrea Image
-        path: antreaImage
-      - description: AntreaPlatform is the platform on which antrea will be deployed.
-        displayName: Antrea Platform
-        path: antreaPlatform
-      statusDescriptors:
-      - description: Conditions describes the state of Antrea installation.
-        displayName: Conditions
-        path: conditions
-      version: v1
-  description: An operator which installs Antrea network CNI plugin on the Kubernetes
-    cluster.
+  description: An operator which installs Antrea network CNI plugin on the Kubernetes cluster.
   displayName: Antrea Operator
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAT4AAAD2CAYAAABP9OtdAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2dW3BV15nnv6MrQkYSCgILDMJAwAW2uZjuGCdpZHdNTdpJF6SmUpPqh7bS/dTVXRVlV6GXfrDy0C9QdUKqZmoe5sFyP/SkH6Ysz0zi7nRPLNrtS/mCwcYUJoCRMchcjCVhQPfT9W2tLR+d9a2917mfvdf/V5XgWmfr3PY+//3dVyqTyRAAALhEHc42AMA1IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwjgacclAuPG9gDxF1ENFm9T8bRviYdProCE4MKBepTCaDLxcUjRK5XiLao/63uwRPO0FEp5QY+v+m00fHtaMAyBMIHygIzxtgS+6w+h8LXnuFvsnTSgiH0umjp7RHAbAAwgesyRG7QzXwzY0S0TBEEOQLhA9E4nkDHJ8bVIJXKcsuX9gSPJ5OHx3CGQVRQPiAEc8b6FWCd9B0TA3CVuBxZQUiHghEIHxAQ1l4QzETvFw4MdIPCxBIQPjAEiqGx9bScwn6VtgC7EN5DMgGwgd8PG+gT4lercbwiuVlJYBwfwGEz3WUlTccc7fWlgklfsPxeLugXED4HMbzBg6rWF5JrbxMQyPNtLXTzfb1NLGila63tNFsUyPdXdupHRvQMD1LD9y8TatmZ6jrzhfUMXOHWu98QY13JrVjS8CLKv4H689RIHyO4nkDnK19vlSf/v669XR1VTddXNMdKnD5woL40NgYbfxyjDpvXaH6+/dK9dSnlfWH+j8HgfA5hnJth0pRgMxid6mzhy5u2kxzzY3a44WQuT9LdZdu0ezUDDU80aM9w+O/fY02Tn5KzU3z2mMFwK7vYSQ+3APC5xBK9EaK6aNlN/ZW9xZ6e+summ57QHu8ECavTtCK0VvUeOEGLVxZ9D4XDmyhxmd2aM+W+fs3/WO2ts3SxtVT1NU2pR1TAD9B2YtbQPgcQQ0R4KC+bkZZwIL3+aYd9M43HyuJdZf6aIymz1+nuau3qXliWns8SvgCOpoW6NG196h79X3t2DyB+DkEhM8BlOiNFJrEuN2znf79kSdKIngzv/mQ6t//TFvPJfO9naKrO/93r2hrpATwDx66Qx2tM9pjefDLdPpof1EfEMQCDCJNOMWI3nTnGvrXAz+gkd1PliyG13jrK21NpGOltGpkfKaO/uVSO711aTVNz9SbDovip6qeESQcCF+CyUpk5C16Y1sepV9/51ma7MovQ3vv9j2aeeMizb03qj1WLJz4iOLK3Qb67YXVdHb9Hppd1RZxtMgLEL/kA+FLKIUmMuZbVtKrT/2A3nx0n/aYCRYkFrrp//kaNf+PE1T/6nnKTMhJh5npOW1Non59h7Y6f82u7G5qPkUnt2yj//v0Yd9NL4AXVI0jSCgQvuRyPF/RY9f21390iL5cY2fl+dbdS6do5r+PUOqfzlLDja/d2KZ1srWVfUwYqZbiXOuVnYuuMrvpv3/0Se1xC4ZUmAAkEAhfAvG8gf58Bw2Mr3/Yd21tYnlzF2/62VXfujs7Rg2CFTe7ovTbuTRO6a8jMbd2eZnNh1u2+1YsZ6bzgMMDw8pyBgkDwpcw1Ay9X+TzqVj0frf/u9p6LoHgpX717rKSklIz3d4sPuPMdbv2taZmXXTZih35w/+cr/j1qBgpSBgQvgSRlcyw5vL2fZGixy7t/D++U3bBC2hpa9HW8mF2lfz3BYrfIWVBgwSh3xpBnBnKp0CZLb2TjzyqrWcz+7uPqf7kp0SCO1tpMlOLNXpzzQ3UpNzZuYcW45GpnsV/G7Z2UVgxSyB+vW//M6XmorPEikHPGxhOp49e1h4BsQTClxCUi2vdf2vj3rJrW/fmpYq7BbNrHqAmbZVo7smt1PTsY8uErZAUSAHi165uKr3aIyCWoHMjASgX95Sttcf1bVzqYQO7uHThVt5f0t2+p6htw/LyQe7JbR16w/9vjuOxS8sWW6p9hV+wzCUsxWZz8+GxS+fpm2feyudP0NaWEGDxJYN+W9Hj+NYrT31fWzcx/Z92UfOFE4ZHzeSKHrOqcyXN/3i/L3ArlcBVTuZ0ONvbdfs6dVz7RHvMwHHl8mKOX8yB8MUcZe1ZB9/f3tubV/sZ18PN7Oz2y1ZsYWtOajhja45jcNWCkzRNX96lzOhtqrs5SXOTU3Tu7jg9ucX6DbWr73pQewTECmR144/1PhncxXC1u1tbZ7gQmWN6EnMHo7sfWOx4ogq7uCv/5hnt8Uph/AwXb/p1h5yZ5rglu+9cTM0tbhdv5DVeqx+1ffEHFl+MUdtAWhUqcyvav+14QlunYGLK2TGavnqbGgTRMll9nF1N7XyQpnZvWnJty+m6BhYbFzIHNX0Nn932/w3KbFL8f3/7J9rfhnHyegutWzVFD7RYZa5h9SUACF+8sXZx333027SwQpcl7rENxkTxXDwuX5Hm4LHVFwgfW3dNB7ZS0871vvsqZWALgXt+uR/XlORgi81/L1muyoJ2VGGcGVtFT2750vZv2eo7jlhffIHwxRTlbllNEfmqa4Po4rIFxQMFsi+ChZOfUubAFk14AquvbtNqWinMycuHQOA41paZuE+Nd+4vs9ju/9XBpeRH9nuV+zksGQ/fq4Nd3p4vW2wHmsLqizkQvvjSZxvbO7HrW9oa0/L/TtNCTmEy993Ovv8pNT21VTu+6YfF9eyzdTnz5kXfskwFbqlgtQUDBpa99pd3tTUJ7tOVCph5WkxKW13OmRsraW3bNNXXW9mRfRC++ILkRnyxcnO5UFnaG4Nn5pnaz+ZOFjdLzzQ3j8VHGjNfSqQ+XVt4mOnlL3TRNdCD0VXxBcIXQ9S4JCt/8/Xte7U1FqbMG5e09QDfIvvIvnyFcmbyzf7TR9rj/jET0W7knEm4IlzVUnH21gqan7f+WWBgaUyB8MUTqx8cb/8oWXtzb14SR0kVQjCTbyH9r0sz+VLt8pAAjuVF0bRWf7+krMViCLK/UfAQ0xuT1tHEQyhtiSeG2yuocaxcrFMb5QEEnMAw3fHY4qp/ejtldunJkGy4/WzV/z9LzQZ3uVqY+nzz4f2pTnqw4YZtH+9hjK6KHxC+mGHr5nLd3tj6B7V1dkfDrD0WPWl3s2zYwms9O6YlJQIyRQwhXWDh1Vbt3GQmtcJe9jgRwjHB7H5h7ixh23L03BnafP6k9jcCEL4YAuGLH1bW3u01G7U1pv6ja2bBMmzpqB136462lk2dYey8KZmy7JiuNlH4/JIXbdWe+V3rKcMC19NJ91Y0+QXXwevoFYNEHzy8w1b4MLElhpg8HlC7WP3QTj/0TW2N43Em8Znf+5CV6DENbSu0tWrBrnndxg6a39ntt8wFc/m09/xEj1+YzRadNEAhF+5n5j1ILGjH3hzxAxZf/DgY9Y7ZzZW2hWz6xNDHuvYBan72MW3dBFtldSGjqmZWt2oXlqnERXuP69rINCiNBS53jFWzKnQuVfdINlc6e2jbbfPnzOKwGgsGYgKEL0aoYaOR3Fm9TjwkdeGGtsZMP/t4cV0ROUgFyNypEVVATGqTIumiTP35Af9fyS0tF+e+0U3bLlg9OSy+mCFdY6B2sfqBXW3XkxrM3JVx7YSzi2ty/TiJIXVr+O7km3Id4JwhOWGCrc3Uhg4/LjjzcJcompUkGITgs7XLn19okd3VvyRQ00D44oXVD+zi2vXamt/rmpPN9feuePoR7VhSnR3+UAJB+MIw1uGN3vYtvkDomnvW0MKWNUuuKlXwYgx6hbkomusDg9l8XIMYWL6c6GGmvtFFLdevac+RA3dxdGBoQXyA8MWLzVHvli2UufZWbb11bIJyi1jq9m3ShhFQMLwgpLMjDFM5yuyejUR7Ni5ZdJmsXt1yw5+H+5Ipd3xV1r+5PwS2Pnntessa2kyRwkfqpjSirYKaBMIXLyLNr5k2g9t6fVJL4TcckEcPS8MLbDGVo5TDhQ3c0gWezTd+jxpvfbUUC8zGP8aQzZZgSzh4v1e+0U2bL38gHKUReVMCtQOEL17IqpbF/RWrtDUSCoC5/KNesPZ4UnGqwG4MntPXGpKVLRTuEmkfv7co3oJbGgjtTHODmKThwaX5yHjDxq+70O416t+RAQhfjIDwxQTbWrHxJln4cguA6x7foB3D1L9+Ie9C4WAwKc/pK8eefdwax4mZwGI1XbSm+KJk7YYxv7FzSUzvrtXLggygZzdGmK4hUHtY/bDutujxPWZmem7pZPubAQmb/vgJkDysvWzBKxS2MDnxwUME6p7YLPYI35+8L1py5WKqZ00hdYHI7MYICF/CuN4it4uxa7j03xtkK6bhrYvamgS7jrPf21mQ4LHbumL0FjVeuOHH3YKBpGxl3vnjlSS9e9sZfqYBBewe50NueQ/vQ9x4J7/nALUNhM9BmrevE13SuUs3lyUm6jbKRiZbZflcOGxJsqjy87cqEZPcaame0I85aqsypgEFddNz4utJSJ95oVF+XhBfIHwOcre7Xdv31ndzyzQdufHUFap7/zMx2xtgGhmfzwBSU7tbPq4yt8RVc5NzUBkwpMAx/PieUFoi9fGyCJQCmyGgqTVyUiafAaSzhnFY+Qi6acgBSBYQPsdoaZOnI0sCk89cPXZJ2WqUmMmKLxpZJwuf7eRkhocW5GJ6TyYahKQPSB5wdR3D5MqxwOTGwUxz9bIJuiK49m+lsJE3t4eFDT6Nei0WTZuLlIuOm4W6RGl3tiCOx8kQjgsG0178OX3a0SCJQPgcw2TF5cbBuMC5KcL64c3Hm9+85AumKUZXd+mWJqgSkqUl9RebMNbwrW6lph/vXxo+mk1uysIkenWzM9oaiDfyrwDElk2Tt2ic9LFUHNvjWJfJssqOg/miFzKcgEtSmn/zwbISGVOMzqZ4WMqkkqG/OHtcPIs4fx5J1AL8eGanXCZjC0pZkgeELz5ctnmnDYYRShzbW7AI8vvC8r1d2noAbzvZ/MoZzX2t27RaO5YMLrT2mgb3m5MVC09vXxxZtbrVFzFpXHyNuKcYUBAjkNyICen0USvh65iR98PgeJYJtuBIxcnm/8sT4sQWUhsVzQ2f0kSP1DQTiajEBlui93fI8wPZ/W16aqv/r5SJrgStN+yTKyA+wOKLFxNRgwpapmThC1xcKfO5cmoxhpV6aotRYFj0eN9cCVOJDAtqa+4MwKx5fH49ofB3tUTXvXDhzsLqxgRqAwhfvDgVtedGs2GPCLbIOHlhsuY4zlb/1FZtnSJEj0Ja4Lg1zTR4lAuNKy15XHLD8Bir1NScP7Em2OT8/g92iyLcOWlt8UH4YgSEL15ECh/TdP02zaxbLkb8o542ZF4p+OFrq8pqCxE9CmmBYzeVlJhWcvBoAGedFy7eWErCBK+f/R0shFiszLr78o0kl3T6KGJ8MQLCFy+srIqHJ7+gj9fpVlhqlz6SnlQsTboQ/Bq8l97T1nNhS64SosYWGw9I4ExxYK1xDHH+L74tCtfCyU/FeGQuDVvk+CSz4gu9o0VgVF8CtYx0vYPaxWoLww0Tn9PHpO+rO/dIt1a7Fsbsq+dC273YUmrY1yMONC0Gf7LyJzf9bhLOCvs1hhPTi3t2ZGXk/Gzx2gdE0ZPiiyamdm8SvxdObFhsNETYWjJ+QPhiBLtTnjcQ+Ybbb3ymrZFyd9mKM8X5svGLh9+Xn4fjgTw7r16YnVcKGk6cp9TZsaVxVWEDBkxWLMcXbWDxNtUA7rhttdcGoZQlfkD44seJqDgfWyltN2+Lm4rbiB4p8cmFC5vnDm5fFFDtUTuCwaPsqkpF0izMmYtW7qWPyYrNfGQnWo075UnUzIYxu011IXzxA8IXP4ZtEhy7P/s9vdb1LW3dBt/a460lFdmCJ4lMGIHbypuZ+/v6Ts/5llywfWMu82evWcXlfLatEd1c//1H1A8G8O5v0q2gYeKubcfGRDp9FK5uzIDwxQ8r66Lz1hUiKkz4eH4eFSF4/uDRc2O+1ZUtQMtG3xumN8+8eTHUtc0ms1/e38d2kjS77JJwMo+PfaKtGRiWl0Etg86NmKGsi8gsYv39e7T58qfaug08qj3z4/2+K2oShlD+4S2qf/X8sl7ebHifDgl2g8OSKdmwaEmDDUhNkrZh3hAfZDZeOaetGYCbG0Ng8cUTtjJ+GvXOd312hi5v3qStR1H/X/8g4ggzUeLFgpUyWHs8bXlB7fXL05S1waLj95bmBt7d8aDYo8vF1mGvHxBmdXZf+9y/cVgwAYsvnkD44smQjfBxF0fz5Fc03Wbu0y2EsMzwwgdXjUXS5G8otFMULKYhS4gyERen/Or2rrLJ6mT2XTqprRkYTqePFrYJMagqcHVjiHJ3T9u882+ff19bKxQWPL8b4v/IsXx+vD4rKZILW3Om0pFS0fKX3/UTJ6ZRV6SGMdTvlN1ctvZMbX8CQ/oSiANhN1VQ2xwnohei3mHHtU+o9caufDbGFpl54yJl3rjkZ1xNGdnZ9z81Wnt+L/AzO7T1UsOWqG85PtFD02p3t8zZz5dlinkYg8lizcPaG0WbWnyBxRdfhlWMKZLe828V/CH9vTT+2+8WkxXTc4vdGobY2NxJOefCgwroR/u19XLjZ6OffYya/rrXtzbZ0vM3QTcMY8jT2juurYDYAOGLKSq2ZPXj4x/zjiuyKJlgt3X+H9+h1K/eXZYsMMXG/AGlQlIhasZfJeDXbnxmhy+A9GdPGl9x/8fWN4gJuLnxBq5uvGHh64+a0cc8cu4d+n3XelpYES1ALGLTwpTlsEzownv6/AS29KaffZzaQkpiuOaPR8xnDx4IenMDokbh28ICuNIgwAfOnMxnxPxxJDXiDYQvxvCPz/MGWPyej/oUXJ7xRx+/RyO7zRYPBV0PPGVZe8Rs7bE7zLusZcMxvaYf7Rd3Pgv+Zv6lU/5mQrmDB5ZtevT0dqNrysy8dMpvcUtt7aK6xzcYa/vC4Pa+7ktnQo5YxgTc3PgjXd8gXlhbfZ2j52lHZzd9vFG22kjFxWae3u7H9LJh663ZYO3Vv35haV8Ndm3r9m0KTWT4mxW9JI+wD1iyFkOywFyzt5RF5n/PjtE9NTGmce8ma/f64Jl/09ZCgLWXAFKZTKHt5qBW8LyBQRurj8k0NNJvvvOnkbV9M7/5kOqzprNwJ4dkTfnW3q/e9f87u8XNhC96/+tto+j5yYcDW40JlKXXjZgKHQhwY4gAM8+8+5qf+baEM7lynxyIFRC+hOB5AxxkC1cLxeyqNvr1ge9HxvtY1GZe+ZCau1YZuzk4ATLf1BgpeBQhev6+vPs2RQoeWYheNpzNNYnfY5fO0zfP5JXx/mE6fRSdGgkAwpcQPG+gl4hetf00X3VtoN8e+GNtXSKsU8MWFqt5VRKzxLY1NL+x0x8tZdsTzDG9sCLpbMKSIhvGxuhb7/yLth7Cy+n00cPmh0GcgPAlCJXoiGxlCxhf/zD9bv93tfVS42eJz1+nVHuL34M70bEyNHYnwUmX+v/9nnHwQS5horf61m3qffufbacrk0po7LHd4hPUPhC+BOF5Ax1qDLqVy0sVFL9iyO4asSEsE1yA6BFc3OQB4UsYnjfAZk5eDbq1Kn5LMUahMFrCT4z8yWNiEoYKF70X0+mjfdoqiDUQvgTieQN9Nn282bD4jTz6pFWBc7nx44G8Q5qlW8vM732IGp9+xBiL5M6VnR++ka/o8SCIXpSvJA8IX0LxvAFuqXoun0/H2d5Xnvo+zTXL4lFO2LrjkVZcjGw9el4VSps2Aw/Yd+4MbT5vPXwgYEKJnjyKBsQaCF+C8bwB/tHuzucTcp3f23t76Wp3eXZQC/CF7vok1V+5vbQXRz5w8mLqDx8OTZLUTc1S75m38qnTy2YvRC+5oHMj2fSq0ejW4seuIJd53Ny4g17bm/+eHf7mQl/e9f+bhS01tShouX24vOFQMMLK+iLctoYy29b6s/R4L9+wfUC4XGX/mddtJynn8hOIXrKBxZdwVKY3L/ELmG9ZSW/v+g6NrX9QeywMLlRecfpTylwdzytOlw13XjStfYDmHur0S2AWtqwxxu+yaZiepe+ce89vzysQFj1MXkk4ED4HKEb8SCU+Xt++t6AR9v54q2vjS9Yfb2RUl+XWLjQ30ELX4jD6VPsKoo6VVL++o6CC6V0Xfk/bz7+bbwIjG4ieI0D4HKFY8WO+ePBhen3HPpprb9UeqyYseNs+OV2oWxsA0XMICJ9DlEL8SFmA7/bsosmu4sbZFwO7tDuuXC6F4HH2th+i5xYQPgcppNRFgstfrnZvow+6H66YFch7BW+5NUrtNz4rxqUNQMmKo0D4HMXzBniG3y9K9elZBK+v2UyfdHbTzQ3rtMcLpWHiLm29cY02THxeKrELQHGyw0D4HEZNdBnKp7fXlunONXR/xSoab1pFV77RTbMZoq9WPWC0DDs+u+7/u2Fqklrv36WuiWvUNDlRSqHL5pfp9NF+bRU4A4TPcVTcj8XvkAPfBO+41IdtIQGED/h43sBhNca+5NZfjfBLIhqEawsIwgeyUdZfv+0Y+5hwQgkerDywBIQPaHjeAO8rMViKzG8VGVWChzIVoAHhA0ZiKoAQPBAJhA9EogSwz3YbyyrxMidpMCkZ2ADhA3mhkiB9NZIFPq0y0sPYDwPkA4QPFIRKhHAd4GH1b6WywZysGIbYgWKA8IGSoNxhFsA9Wf8r1i1mi+6y2kBpBJlZUCogfKCsqO4QUmLYEfFaLHBcZ3cZ1hwoJxA+AIBz1OGUAwBcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHCOBhc+sOcd6SeijpzlU+n0sWHt4NK9Zi8R9eYsD6fTx05pB5f/dYfS6WOXhWP7iGiz9iSVYySdPjYivC/pM+TLOJ9j9TeXpc9fCJ53hL+vvip8V+I5LBTPO8K/h37hz0v6OrVK4oVPXai/0B4gGmUh0lZLB/9wn895tn5+P+n0sfEKvy6Li3Qx8w/4oLZaWTThM3yGovC8I6PqtYaLvOFtLvV7s8R0Dgulz/A5qiXsFcUFV3dQW1mkR1k8laS9zGILzPQQ0XNE9JLnHblchXNfa0jWHvOcsgYTTaKFT53Aw9oDX2M6+eXkoOcdMYkxqAwsgi943pER5RE4hRL9npDPXI3fRUVJusXXr6wsE7tVPKnSPO95R8IEGVQGdvNPed6RPY5931HWbuKFL+kxPht3ps8QZyo3Q/yDq3IgWUr62PBqzjGnC/yx5PPZf5aVrLBlj4pZ8c1tt+Fv+MbIll9vEYmnF/l8aqulpSRJMXWjj4rrtrNVmE4fK/dnqhqJFT4Lcz6AYxqDVRCgIN5XNWuj0B+65x3JXRqXsrMl5lQBr7F0fFY2VvICAvErNPF0uQKfv1TYxjYHKyDmVSPJrq5kgbyorBObYysBu9rHq/TaTsE3tnT62KC60ZwQPjuLX6LPhRJ/TvDk8nNtZTH5V40wUEVIpPCpEya5NoOGi7uvQpmsCW2F6KeI91UOJYC96iaYy3MJT3ZIN/hRdUOQvg/p+ESQVItPOmEn1EU/pGr4smmvUO3SoEH8hhwMsFebfuE6IMO1E3vUjV26xgNDQHJrDyX1RpA44VMn6pD2wHJLTzrJlbjgTxlep12JX+Lrp2oFFcuTyoqSan0fFmKbE8FvQcUopRCA9B3FniRafJKwjOZU60vubkUKmpXFKbkVuw3vC5T3XOTSk9AbkCRgQznJHOn7OJzE7yNRwhdizi876epkS+Ij/W056DckWZ5DR0HFkaycRIUdVAxZqnBYdqMNCQNJxkSsSZrF12cw56U2MekOeLASsTYlvIcN8b7jiPeBEiMJ14uGEi7J6kvczThpwied4ONSbZY66dLdXnqOkqNeX7qgEO8DJUPdRKWCZUngSFmBuTfkavS1l5XECF9IwbLpBJPB6qtYSYOKO/5Se2Ax3hf2vkHpSPoNRrqRnzAVXCsjQfKQpOeJLUmy+KQ7ksmc91EnXyppkJ6rLKTTx0zxvkNqjiAoE+oGp9V7mkQhboQULEfdVCWDoFp97WUhEcIX0n9okyWVTnJ/hV1NU7zvF4j3lRXpBifdhJL0+bjCIVT4lLHwsvaA/HyxJCm9utIJOWHZizqsBDI7KdKuxCj0AikVfKGpzFtu87///tQwAy1OCQpH3VCkQZyFnPPeMo0au1zkoADJY7AtmTou1MNWq6+95MRe+ELMeasTzIKi+mVzfwQVbdJm98rzjvxceB896n2gra1EKNGT3NmJAs/5QYPHUSwnCr0GVcxbqnCwej51PY4KcfN+g6DGiiS4upK1l1uwHIV0MfRUuodW9UxKmeZDGF5aGlTcdEQQBWYwQZa1dL3kFiwX8hyV6msvK7EWvpANU6QTZkSZ7lJBs/Tc5cYU73s+ydMyyglbeCx4PHJe7b8iid7L6fSxRHTOqOtEqnDI6/MpNzv3WqxUX3tZibura+o/LGRfi+OCy3xQzWirWExDud5h8b5yb1ZUq3BhdyGfe49wjeRyOmFFutKNP7TCIQQpDNQf9/bKuAufdILFguUoOBHieUdOCLGawUr/KFR85WfC7nDB8FIXLT+t7KREcPayr8ibyc9VmKLqqJi3FG+Uwjk2SMLXE/cJzbF1dUP6D4s5GdLfVmXXKeV2SSUF2KyoNLBn8LN0+tjhhFnQ0rVhLFiOogb62stCnGN8UvytUHPex9CkbXqtStBneD/YrKhwJtTE4c1JiekFqBu0VMa1YrsAAAQxSURBVOEg3dDzQRLTivS1l4tYCl9I/2EpLmTpOaoifFnDDCSGXNwasQAmVKacWwN/mE4f62C3NKFxUuk6jSxYjqLafe3lIK4xPukLZ8uoowSZT8lirNquUyr2GBbvc6Wz4+kod03VY/40Z9kfq1TEDmpxQnI/T5WoGmBEMDZiW9AcO+ELMed7DJnQUlG1XafYJVNWbu7n9jcrUv2+zsPfg2G/lSG1fWRis+EhQzoOCR0YpaTP4ArXNHF0dav1I6/2rlOmYQbYrGg5ktWzO6kj1LOo1u+i0n3tJQHCF5PXVtZKn1BQStis6GuUS/sz7YHFG0Qiy4AMVm6laA+JQ9cssRI+Q/9hJanqrlPqRy2JL4aXZqGytVIwfjih35F0TVSS2FnTcYvxSV/wCUPDeSmQ4iYVL2jOhhMs6g6vxftURjr2kzNKxGH1XeRO3UnUwIeQXQVfLOO1IBU098ZpjmFshC+k/7CvXFkl1dv5Qs6yv+tUlQPl/Sqbm+vePGeIAzqHav3jG9RLOZ/dH/CaoBo+ydrjEpay3ZxVWCVXbAfj1FEUJ1dXsvZeLmcqPaRJW7rYKkbEZkXVivXUHGpCj9R1MJiEGkjbXQXLgHTTOBin7zQWwhfSfyidgFIjvYZ0sVWUkM2KwHL6he6X9gIHWdQaUsy70CEd1iiXVvIsYhPri4vFJ32hoxWKKUjCVxO7ToVsVgS+/o7GDTeI3QnoeZY8j4KGdBSA9LuoSl97IdR8jE99kVIwuiIXrYoVvSgkE/prYSe0kKJd8PV3ZJpuzT3PwyXo6uDnkcbYl5JlnSshBcuV2i5hSN04pAnNNX9DiYPF1y+Z8xVuH5NOZC3tOmWK9wGFGhsluWdxLXGRrNiihnQUgPQblKzQmiMOwiedYMnMLhshTdrSe6s46v1JVjFYjnSD6InbUM0idxUsJdLm4+1x2Hy8poUvxJyvxoUqvWbFNh+PQrlBP484zGnUDUKy3p+LWdufJCy2uwqWjDhvPl7rMb49gqU1Uo0aOk4keN6Rl4Wd93sNJr9kJZb1fbM7p4Q4V4xL/bq5n6vUP7iyfXdq4MNmYapNn+FHnMu48N4qQfbn3yy8B0nQK8GgcL1RpbdsyJdUJpOp1fcGAABlIQnbSwIAQF5A+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAbkFE/wE3LmoBviFqiAAAAABJRU5ErkJggg==
-    mediatype: image/png
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAT4AAAD2CAYAAABP9OtdAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nO2dW3BV15nnv6MrQkYSCgILDMJAwAW2uZjuGCdpZHdNTdpJF6SmUpPqh7bS/dTVXRVlV6GXfrDy0C9QdUKqZmoe5sFyP/SkH6Ysz0zi7nRPLNrtS/mCwcYUJoCRMchcjCVhQPfT9W2tLR+d9a2917mfvdf/V5XgWmfr3PY+//3dVyqTyRAAALhEHc42AMA1IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwDggfAMA5IHwAAOeA8AEAnAPCBwBwjgacclAuPG9gDxF1ENFm9T8bRviYdProCE4MKBepTCaDLxcUjRK5XiLao/63uwRPO0FEp5QY+v+m00fHtaMAyBMIHygIzxtgS+6w+h8LXnuFvsnTSgiH0umjp7RHAbAAwgesyRG7QzXwzY0S0TBEEOQLhA9E4nkDHJ8bVIJXKcsuX9gSPJ5OHx3CGQVRQPiAEc8b6FWCd9B0TA3CVuBxZQUiHghEIHxAQ1l4QzETvFw4MdIPCxBIQPjAEiqGx9bScwn6VtgC7EN5DMgGwgd8PG+gT4lercbwiuVlJYBwfwGEz3WUlTccc7fWlgklfsPxeLugXED4HMbzBg6rWF5JrbxMQyPNtLXTzfb1NLGila63tNFsUyPdXdupHRvQMD1LD9y8TatmZ6jrzhfUMXOHWu98QY13JrVjS8CLKv4H689RIHyO4nkDnK19vlSf/v669XR1VTddXNMdKnD5woL40NgYbfxyjDpvXaH6+/dK9dSnlfWH+j8HgfA5hnJth0pRgMxid6mzhy5u2kxzzY3a44WQuT9LdZdu0ezUDDU80aM9w+O/fY02Tn5KzU3z2mMFwK7vYSQ+3APC5xBK9EaK6aNlN/ZW9xZ6e+summ57QHu8ECavTtCK0VvUeOEGLVxZ9D4XDmyhxmd2aM+W+fs3/WO2ts3SxtVT1NU2pR1TAD9B2YtbQPgcQQ0R4KC+bkZZwIL3+aYd9M43HyuJdZf6aIymz1+nuau3qXliWns8SvgCOpoW6NG196h79X3t2DyB+DkEhM8BlOiNFJrEuN2znf79kSdKIngzv/mQ6t//TFvPJfO9naKrO/93r2hrpATwDx66Qx2tM9pjefDLdPpof1EfEMQCDCJNOMWI3nTnGvrXAz+gkd1PliyG13jrK21NpGOltGpkfKaO/uVSO711aTVNz9SbDovip6qeESQcCF+CyUpk5C16Y1sepV9/51ma7MovQ3vv9j2aeeMizb03qj1WLJz4iOLK3Qb67YXVdHb9Hppd1RZxtMgLEL/kA+FLKIUmMuZbVtKrT/2A3nx0n/aYCRYkFrrp//kaNf+PE1T/6nnKTMhJh5npOW1Non59h7Y6f82u7G5qPkUnt2yj//v0Yd9NL4AXVI0jSCgQvuRyPF/RY9f21390iL5cY2fl+dbdS6do5r+PUOqfzlLDja/d2KZ1srWVfUwYqZbiXOuVnYuuMrvpv3/0Se1xC4ZUmAAkEAhfAvG8gf58Bw2Mr3/Yd21tYnlzF2/62VXfujs7Rg2CFTe7ovTbuTRO6a8jMbd2eZnNh1u2+1YsZ6bzgMMDw8pyBgkDwpcw1Ay9X+TzqVj0frf/u9p6LoHgpX717rKSklIz3d4sPuPMdbv2taZmXXTZih35w/+cr/j1qBgpSBgQvgSRlcyw5vL2fZGixy7t/D++U3bBC2hpa9HW8mF2lfz3BYrfIWVBgwSh3xpBnBnKp0CZLb2TjzyqrWcz+7uPqf7kp0SCO1tpMlOLNXpzzQ3UpNzZuYcW45GpnsV/G7Z2UVgxSyB+vW//M6XmorPEikHPGxhOp49e1h4BsQTClxCUi2vdf2vj3rJrW/fmpYq7BbNrHqAmbZVo7smt1PTsY8uErZAUSAHi165uKr3aIyCWoHMjASgX95Sttcf1bVzqYQO7uHThVt5f0t2+p6htw/LyQe7JbR16w/9vjuOxS8sWW6p9hV+wzCUsxWZz8+GxS+fpm2feyudP0NaWEGDxJYN+W9Hj+NYrT31fWzcx/Z92UfOFE4ZHzeSKHrOqcyXN/3i/L3ArlcBVTuZ0ONvbdfs6dVz7RHvMwHHl8mKOX8yB8MUcZe1ZB9/f3tubV/sZ18PN7Oz2y1ZsYWtOajhja45jcNWCkzRNX96lzOhtqrs5SXOTU3Tu7jg9ucX6DbWr73pQewTECmR144/1PhncxXC1u1tbZ7gQmWN6EnMHo7sfWOx4ogq7uCv/5hnt8Uph/AwXb/p1h5yZ5rglu+9cTM0tbhdv5DVeqx+1ffEHFl+MUdtAWhUqcyvav+14QlunYGLK2TGavnqbGgTRMll9nF1N7XyQpnZvWnJty+m6BhYbFzIHNX0Nn932/w3KbFL8f3/7J9rfhnHyegutWzVFD7RYZa5h9SUACF+8sXZx333027SwQpcl7rENxkTxXDwuX5Hm4LHVFwgfW3dNB7ZS0871vvsqZWALgXt+uR/XlORgi81/L1muyoJ2VGGcGVtFT2750vZv2eo7jlhffIHwxRTlbllNEfmqa4Po4rIFxQMFsi+ChZOfUubAFk14AquvbtNqWinMycuHQOA41paZuE+Nd+4vs9ju/9XBpeRH9nuV+zksGQ/fq4Nd3p4vW2wHmsLqizkQvvjSZxvbO7HrW9oa0/L/TtNCTmEy993Ovv8pNT21VTu+6YfF9eyzdTnz5kXfskwFbqlgtQUDBpa99pd3tTUJ7tOVCph5WkxKW13OmRsraW3bNNXXW9mRfRC++ILkRnyxcnO5UFnaG4Nn5pnaz+ZOFjdLzzQ3j8VHGjNfSqQ+XVt4mOnlL3TRNdCD0VXxBcIXQ9S4JCt/8/Xte7U1FqbMG5e09QDfIvvIvnyFcmbyzf7TR9rj/jET0W7knEm4IlzVUnH21gqan7f+WWBgaUyB8MUTqx8cb/8oWXtzb14SR0kVQjCTbyH9r0sz+VLt8pAAjuVF0bRWf7+krMViCLK/UfAQ0xuT1tHEQyhtiSeG2yuocaxcrFMb5QEEnMAw3fHY4qp/ejtldunJkGy4/WzV/z9LzQZ3uVqY+nzz4f2pTnqw4YZtH+9hjK6KHxC+mGHr5nLd3tj6B7V1dkfDrD0WPWl3s2zYwms9O6YlJQIyRQwhXWDh1Vbt3GQmtcJe9jgRwjHB7H5h7ixh23L03BnafP6k9jcCEL4YAuGLH1bW3u01G7U1pv6ja2bBMmzpqB136462lk2dYey8KZmy7JiuNlH4/JIXbdWe+V3rKcMC19NJ91Y0+QXXwevoFYNEHzy8w1b4MLElhpg8HlC7WP3QTj/0TW2N43Em8Znf+5CV6DENbSu0tWrBrnndxg6a39ntt8wFc/m09/xEj1+YzRadNEAhF+5n5j1ILGjH3hzxAxZf/DgY9Y7ZzZW2hWz6xNDHuvYBan72MW3dBFtldSGjqmZWt2oXlqnERXuP69rINCiNBS53jFWzKnQuVfdINlc6e2jbbfPnzOKwGgsGYgKEL0aoYaOR3Fm9TjwkdeGGtsZMP/t4cV0ROUgFyNypEVVATGqTIumiTP35Af9fyS0tF+e+0U3bLlg9OSy+mCFdY6B2sfqBXW3XkxrM3JVx7YSzi2ty/TiJIXVr+O7km3Id4JwhOWGCrc3Uhg4/LjjzcJcompUkGITgs7XLn19okd3VvyRQ00D44oXVD+zi2vXamt/rmpPN9feuePoR7VhSnR3+UAJB+MIw1uGN3vYtvkDomnvW0MKWNUuuKlXwYgx6hbkomusDg9l8XIMYWL6c6GGmvtFFLdevac+RA3dxdGBoQXyA8MWLzVHvli2UufZWbb11bIJyi1jq9m3ShhFQMLwgpLMjDFM5yuyejUR7Ni5ZdJmsXt1yw5+H+5Ipd3xV1r+5PwS2Pnntessa2kyRwkfqpjSirYKaBMIXLyLNr5k2g9t6fVJL4TcckEcPS8MLbDGVo5TDhQ3c0gWezTd+jxpvfbUUC8zGP8aQzZZgSzh4v1e+0U2bL38gHKUReVMCtQOEL17IqpbF/RWrtDUSCoC5/KNesPZ4UnGqwG4MntPXGpKVLRTuEmkfv7co3oJbGgjtTHODmKThwaX5yHjDxq+70O416t+RAQhfjIDwxQTbWrHxJln4cguA6x7foB3D1L9+Ie9C4WAwKc/pK8eefdwax4mZwGI1XbSm+KJk7YYxv7FzSUzvrtXLggygZzdGmK4hUHtY/bDutujxPWZmem7pZPubAQmb/vgJkDysvWzBKxS2MDnxwUME6p7YLPYI35+8L1py5WKqZ00hdYHI7MYICF/CuN4it4uxa7j03xtkK6bhrYvamgS7jrPf21mQ4LHbumL0FjVeuOHH3YKBpGxl3vnjlSS9e9sZfqYBBewe50NueQ/vQ9x4J7/nALUNhM9BmrevE13SuUs3lyUm6jbKRiZbZflcOGxJsqjy87cqEZPcaame0I85aqsypgEFddNz4utJSJ95oVF+XhBfIHwOcre7Xdv31ndzyzQdufHUFap7/zMx2xtgGhmfzwBSU7tbPq4yt8RVc5NzUBkwpMAx/PieUFoi9fGyCJQCmyGgqTVyUiafAaSzhnFY+Qi6acgBSBYQPsdoaZOnI0sCk89cPXZJ2WqUmMmKLxpZJwuf7eRkhocW5GJ6TyYahKQPSB5wdR3D5MqxwOTGwUxz9bIJuiK49m+lsJE3t4eFDT6Nei0WTZuLlIuOm4W6RGl3tiCOx8kQjgsG0178OX3a0SCJQPgcw2TF5cbBuMC5KcL64c3Hm9+85AumKUZXd+mWJqgSkqUl9RebMNbwrW6lph/vXxo+mk1uysIkenWzM9oaiDfyrwDElk2Tt2ic9LFUHNvjWJfJssqOg/miFzKcgEtSmn/zwbISGVOMzqZ4WMqkkqG/OHtcPIs4fx5J1AL8eGanXCZjC0pZkgeELz5ctnmnDYYRShzbW7AI8vvC8r1d2noAbzvZ/MoZzX2t27RaO5YMLrT2mgb3m5MVC09vXxxZtbrVFzFpXHyNuKcYUBAjkNyICen0USvh65iR98PgeJYJtuBIxcnm/8sT4sQWUhsVzQ2f0kSP1DQTiajEBlui93fI8wPZ/W16aqv/r5SJrgStN+yTKyA+wOKLFxNRgwpapmThC1xcKfO5cmoxhpV6aotRYFj0eN9cCVOJDAtqa+4MwKx5fH49ofB3tUTXvXDhzsLqxgRqAwhfvDgVtedGs2GPCLbIOHlhsuY4zlb/1FZtnSJEj0Ja4Lg1zTR4lAuNKy15XHLD8Bir1NScP7Em2OT8/g92iyLcOWlt8UH4YgSEL15ECh/TdP02zaxbLkb8o542ZF4p+OFrq8pqCxE9CmmBYzeVlJhWcvBoAGedFy7eWErCBK+f/R0shFiszLr78o0kl3T6KGJ8MQLCFy+srIqHJ7+gj9fpVlhqlz6SnlQsTboQ/Bq8l97T1nNhS64SosYWGw9I4ExxYK1xDHH+L74tCtfCyU/FeGQuDVvk+CSz4gu9o0VgVF8CtYx0vYPaxWoLww0Tn9PHpO+rO/dIt1a7Fsbsq+dC273YUmrY1yMONC0Gf7LyJzf9bhLOCvs1hhPTi3t2ZGXk/Gzx2gdE0ZPiiyamdm8SvxdObFhsNETYWjJ+QPhiBLtTnjcQ+Ybbb3ymrZFyd9mKM8X5svGLh9+Xn4fjgTw7r16YnVcKGk6cp9TZsaVxVWEDBkxWLMcXbWDxNtUA7rhttdcGoZQlfkD44seJqDgfWyltN2+Lm4rbiB4p8cmFC5vnDm5fFFDtUTuCwaPsqkpF0izMmYtW7qWPyYrNfGQnWo075UnUzIYxu011IXzxA8IXP4ZtEhy7P/s9vdb1LW3dBt/a460lFdmCJ4lMGIHbypuZ+/v6Ts/5llywfWMu82evWcXlfLatEd1c//1H1A8G8O5v0q2gYeKubcfGRDp9FK5uzIDwxQ8r66Lz1hUiKkz4eH4eFSF4/uDRc2O+1ZUtQMtG3xumN8+8eTHUtc0ms1/e38d2kjS77JJwMo+PfaKtGRiWl0Etg86NmKGsi8gsYv39e7T58qfaug08qj3z4/2+K2oShlD+4S2qf/X8sl7ebHifDgl2g8OSKdmwaEmDDUhNkrZh3hAfZDZeOaetGYCbG0Ng8cUTtjJ+GvXOd312hi5v3qStR1H/X/8g4ggzUeLFgpUyWHs8bXlB7fXL05S1waLj95bmBt7d8aDYo8vF1mGvHxBmdXZf+9y/cVgwAYsvnkD44smQjfBxF0fz5Fc03Wbu0y2EsMzwwgdXjUXS5G8otFMULKYhS4gyERen/Or2rrLJ6mT2XTqprRkYTqePFrYJMagqcHVjiHJ3T9u882+ff19bKxQWPL8b4v/IsXx+vD4rKZILW3Om0pFS0fKX3/UTJ6ZRV6SGMdTvlN1ctvZMbX8CQ/oSiANhN1VQ2xwnohei3mHHtU+o9caufDbGFpl54yJl3rjkZ1xNGdnZ9z81Wnt+L/AzO7T1UsOWqG85PtFD02p3t8zZz5dlinkYg8lizcPaG0WbWnyBxRdfhlWMKZLe828V/CH9vTT+2+8WkxXTc4vdGobY2NxJOefCgwroR/u19XLjZ6OffYya/rrXtzbZ0vM3QTcMY8jT2juurYDYAOGLKSq2ZPXj4x/zjiuyKJlgt3X+H9+h1K/eXZYsMMXG/AGlQlIhasZfJeDXbnxmhy+A9GdPGl9x/8fWN4gJuLnxBq5uvGHh64+a0cc8cu4d+n3XelpYES1ALGLTwpTlsEzownv6/AS29KaffZzaQkpiuOaPR8xnDx4IenMDokbh28ICuNIgwAfOnMxnxPxxJDXiDYQvxvCPz/MGWPyej/oUXJ7xRx+/RyO7zRYPBV0PPGVZe8Rs7bE7zLusZcMxvaYf7Rd3Pgv+Zv6lU/5mQrmDB5ZtevT0dqNrysy8dMpvcUtt7aK6xzcYa/vC4Pa+7ktnQo5YxgTc3PgjXd8gXlhbfZ2j52lHZzd9vFG22kjFxWae3u7H9LJh663ZYO3Vv35haV8Ndm3r9m0KTWT4mxW9JI+wD1iyFkOywFyzt5RF5n/PjtE9NTGmce8ma/f64Jl/09ZCgLWXAFKZTKHt5qBW8LyBQRurj8k0NNJvvvOnkbV9M7/5kOqzprNwJ4dkTfnW3q/e9f87u8XNhC96/+tto+j5yYcDW40JlKXXjZgKHQhwY4gAM8+8+5qf+baEM7lynxyIFRC+hOB5AxxkC1cLxeyqNvr1ge9HxvtY1GZe+ZCau1YZuzk4ATLf1BgpeBQhev6+vPs2RQoeWYheNpzNNYnfY5fO0zfP5JXx/mE6fRSdGgkAwpcQPG+gl4hetf00X3VtoN8e+GNtXSKsU8MWFqt5VRKzxLY1NL+x0x8tZdsTzDG9sCLpbMKSIhvGxuhb7/yLth7Cy+n00cPmh0GcgPAlCJXoiGxlCxhf/zD9bv93tfVS42eJz1+nVHuL34M70bEyNHYnwUmX+v/9nnHwQS5horf61m3qffufbacrk0po7LHd4hPUPhC+BOF5Ax1qDLqVy0sVFL9iyO4asSEsE1yA6BFc3OQB4UsYnjfAZk5eDbq1Kn5LMUahMFrCT4z8yWNiEoYKF70X0+mjfdoqiDUQvgTieQN9Nn282bD4jTz6pFWBc7nx44G8Q5qlW8vM732IGp9+xBiL5M6VnR++ka/o8SCIXpSvJA8IX0LxvAFuqXoun0/H2d5Xnvo+zTXL4lFO2LrjkVZcjGw9el4VSps2Aw/Yd+4MbT5vPXwgYEKJnjyKBsQaCF+C8bwB/tHuzucTcp3f23t76Wp3eXZQC/CF7vok1V+5vbQXRz5w8mLqDx8OTZLUTc1S75m38qnTy2YvRC+5oHMj2fSq0ejW4seuIJd53Ny4g17bm/+eHf7mQl/e9f+bhS01tShouX24vOFQMMLK+iLctoYy29b6s/R4L9+wfUC4XGX/mddtJynn8hOIXrKBxZdwVKY3L/ELmG9ZSW/v+g6NrX9QeywMLlRecfpTylwdzytOlw13XjStfYDmHur0S2AWtqwxxu+yaZiepe+ce89vzysQFj1MXkk4ED4HKEb8SCU+Xt++t6AR9v54q2vjS9Yfb2RUl+XWLjQ30ELX4jD6VPsKoo6VVL++o6CC6V0Xfk/bz7+bbwIjG4ieI0D4HKFY8WO+ePBhen3HPpprb9UeqyYseNs+OV2oWxsA0XMICJ9DlEL8SFmA7/bsosmu4sbZFwO7tDuuXC6F4HH2th+i5xYQPgcppNRFgstfrnZvow+6H66YFch7BW+5NUrtNz4rxqUNQMmKo0D4HMXzBniG3y9K9elZBK+v2UyfdHbTzQ3rtMcLpWHiLm29cY02THxeKrELQHGyw0D4HEZNdBnKp7fXlunONXR/xSoab1pFV77RTbMZoq9WPWC0DDs+u+7/u2Fqklrv36WuiWvUNDlRSqHL5pfp9NF+bRU4A4TPcVTcj8XvkAPfBO+41IdtIQGED/h43sBhNca+5NZfjfBLIhqEawsIwgeyUdZfv+0Y+5hwQgkerDywBIQPaHjeAO8rMViKzG8VGVWChzIVoAHhA0ZiKoAQPBAJhA9EogSwz3YbyyrxMidpMCkZ2ADhA3mhkiB9NZIFPq0y0sPYDwPkA4QPFIRKhHAd4GH1b6WywZysGIbYgWKA8IGSoNxhFsA9Wf8r1i1mi+6y2kBpBJlZUCogfKCsqO4QUmLYEfFaLHBcZ3cZ1hwoJxA+AIBz1OGUAwBcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHAOCB8AwDkgfAAA54DwAQCcA8IHAHCOBhc+sOcd6SeijpzlU+n0sWHt4NK9Zi8R9eYsD6fTx05pB5f/dYfS6WOXhWP7iGiz9iSVYySdPjYivC/pM+TLOJ9j9TeXpc9fCJ53hL+vvip8V+I5LBTPO8K/h37hz0v6OrVK4oVPXai/0B4gGmUh0lZLB/9wn895tn5+P+n0sfEKvy6Li3Qx8w/4oLZaWTThM3yGovC8I6PqtYaLvOFtLvV7s8R0Dgulz/A5qiXsFcUFV3dQW1mkR1k8laS9zGILzPQQ0XNE9JLnHblchXNfa0jWHvOcsgYTTaKFT53Aw9oDX2M6+eXkoOcdMYkxqAwsgi943pER5RE4hRL9npDPXI3fRUVJusXXr6wsE7tVPKnSPO95R8IEGVQGdvNPed6RPY5931HWbuKFL+kxPht3ps8QZyo3Q/yDq3IgWUr62PBqzjGnC/yx5PPZf5aVrLBlj4pZ8c1tt+Fv+MbIll9vEYmnF/l8aqulpSRJMXWjj4rrtrNVmE4fK/dnqhqJFT4Lcz6AYxqDVRCgIN5XNWuj0B+65x3JXRqXsrMl5lQBr7F0fFY2VvICAvErNPF0uQKfv1TYxjYHKyDmVSPJrq5kgbyorBObYysBu9rHq/TaTsE3tnT62KC60ZwQPjuLX6LPhRJ/TvDk8nNtZTH5V40wUEVIpPCpEya5NoOGi7uvQpmsCW2F6KeI91UOJYC96iaYy3MJT3ZIN/hRdUOQvg/p+ESQVItPOmEn1EU/pGr4smmvUO3SoEH8hhwMsFebfuE6IMO1E3vUjV26xgNDQHJrDyX1RpA44VMn6pD2wHJLTzrJlbjgTxlep12JX+Lrp2oFFcuTyoqSan0fFmKbE8FvQcUopRCA9B3FniRafJKwjOZU60vubkUKmpXFKbkVuw3vC5T3XOTSk9AbkCRgQznJHOn7OJzE7yNRwhdizi876epkS+Ij/W056DckWZ5DR0HFkaycRIUdVAxZqnBYdqMNCQNJxkSsSZrF12cw56U2MekOeLASsTYlvIcN8b7jiPeBEiMJ14uGEi7J6kvczThpwied4ONSbZY66dLdXnqOkqNeX7qgEO8DJUPdRKWCZUngSFmBuTfkavS1l5XECF9IwbLpBJPB6qtYSYOKO/5Se2Ax3hf2vkHpSPoNRrqRnzAVXCsjQfKQpOeJLUmy+KQ7ksmc91EnXyppkJ6rLKTTx0zxvkNqjiAoE+oGp9V7mkQhboQULEfdVCWDoFp97WUhEcIX0n9okyWVTnJ/hV1NU7zvF4j3lRXpBifdhJL0+bjCIVT4lLHwsvaA/HyxJCm9utIJOWHZizqsBDI7KdKuxCj0AikVfKGpzFtu87///tQwAy1OCQpH3VCkQZyFnPPeMo0au1zkoADJY7AtmTou1MNWq6+95MRe+ELMeasTzIKi+mVzfwQVbdJm98rzjvxceB896n2gra1EKNGT3NmJAs/5QYPHUSwnCr0GVcxbqnCwej51PY4KcfN+g6DGiiS4upK1l1uwHIV0MfRUuodW9UxKmeZDGF5aGlTcdEQQBWYwQZa1dL3kFiwX8hyV6msvK7EWvpANU6QTZkSZ7lJBs/Tc5cYU73s+ydMyyglbeCx4PHJe7b8iid7L6fSxRHTOqOtEqnDI6/MpNzv3WqxUX3tZibura+o/LGRfi+OCy3xQzWirWExDud5h8b5yb1ZUq3BhdyGfe49wjeRyOmFFutKNP7TCIQQpDNQf9/bKuAufdILFguUoOBHieUdOCLGawUr/KFR85WfC7nDB8FIXLT+t7KREcPayr8ibyc9VmKLqqJi3FG+Uwjk2SMLXE/cJzbF1dUP6D4s5GdLfVmXXKeV2SSUF2KyoNLBn8LN0+tjhhFnQ0rVhLFiOogb62stCnGN8UvytUHPex9CkbXqtStBneD/YrKhwJtTE4c1JiekFqBu0VMa1YrsAAAQxSURBVOEg3dDzQRLTivS1l4tYCl9I/2EpLmTpOaoifFnDDCSGXNwasQAmVKacWwN/mE4f62C3NKFxUuk6jSxYjqLafe3lIK4xPukLZ8uoowSZT8lirNquUyr2GBbvc6Wz4+kod03VY/40Z9kfq1TEDmpxQnI/T5WoGmBEMDZiW9AcO+ELMed7DJnQUlG1XafYJVNWbu7n9jcrUv2+zsPfg2G/lSG1fWRis+EhQzoOCR0YpaTP4ArXNHF0dav1I6/2rlOmYQbYrGg5ktWzO6kj1LOo1u+i0n3tJQHCF5PXVtZKn1BQStis6GuUS/sz7YHFG0Qiy4AMVm6laA+JQ9cssRI+Q/9hJanqrlPqRy2JL4aXZqGytVIwfjih35F0TVSS2FnTcYvxSV/wCUPDeSmQ4iYVL2jOhhMs6g6vxftURjr2kzNKxGH1XeRO3UnUwIeQXQVfLOO1IBU098ZpjmFshC+k/7CvXFkl1dv5Qs6yv+tUlQPl/Sqbm+vePGeIAzqHav3jG9RLOZ/dH/CaoBo+ydrjEpay3ZxVWCVXbAfj1FEUJ1dXsvZeLmcqPaRJW7rYKkbEZkXVivXUHGpCj9R1MJiEGkjbXQXLgHTTOBin7zQWwhfSfyidgFIjvYZ0sVWUkM2KwHL6he6X9gIHWdQaUsy70CEd1iiXVvIsYhPri4vFJ32hoxWKKUjCVxO7ToVsVgS+/o7GDTeI3QnoeZY8j4KGdBSA9LuoSl97IdR8jE99kVIwuiIXrYoVvSgkE/prYSe0kKJd8PV3ZJpuzT3PwyXo6uDnkcbYl5JlnSshBcuV2i5hSN04pAnNNX9DiYPF1y+Z8xVuH5NOZC3tOmWK9wGFGhsluWdxLXGRrNiihnQUgPQblKzQmiMOwiedYMnMLhshTdrSe6s46v1JVjFYjnSD6InbUM0idxUsJdLm4+1x2Hy8poUvxJyvxoUqvWbFNh+PQrlBP484zGnUDUKy3p+LWdufJCy2uwqWjDhvPl7rMb49gqU1Uo0aOk4keN6Rl4Wd93sNJr9kJZb1fbM7p4Q4V4xL/bq5n6vUP7iyfXdq4MNmYapNn+FHnMu48N4qQfbn3yy8B0nQK8GgcL1RpbdsyJdUJpOp1fcGAABlIQnbSwIAQF5A+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAzgHhAwA4B4QPAOAcED4AgHNA+AAAbkFE/wE3LmoBviFqiAAAAABJRU5ErkJggg==
+      mediatype: image/png
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - nonResourceURLs:
-          - /addressgroups
-          - /agentinfo
-          - /appliedtogroups
-          - /networkpolicies
-          - /ovsflows
-          - /ovstracing
-          - /podinterfaces
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - namespaces
-          - pods
-          - serviceaccounts
-          - services
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          - validatingwebhookconfigurations
-          verbs:
-          - create
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apiregistration.k8s.io
-          resources:
-          - apiservices
-          verbs:
-          - create
-          - delete
-          - get
-          - update
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusteroperators
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - clusteroperators/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - config.openshift.io
-          resources:
-          - networks
-          - networks/finalizers
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - controlplane.antrea.io
-          resources:
-          - addressgroups
-          - appliedtogroups
-          - networkpolicies
-          verbs:
-          - delete
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - crd.antrea.io
-          resources:
-          - antreaagentinfos
-          - antreacontrollerinfos
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-        - apiGroups:
-          - crd.antrea.io
-          resources:
-          - clusternetworkpolicies
-          verbs:
-          - delete
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - crd.antrea.io
-          resources:
-          - traceflows
-          - traceflows/status
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - networking.k8s.io
-          resources:
-          - networkpolicies
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - operator.antrea.vmware.com
-          resources:
-          - antreainstalls
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.antrea.vmware.com
-          resources:
-          - antreainstalls/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.openshift.io
-          resources:
-          - networks
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - security.openshift.io
-          resourceNames:
-          - hostnetwork
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - use
-        - apiGroups:
-          - system.antrea.io
-          resources:
-          - agentinfos
-          - supportbundles
-          - supportbundles/download
-          verbs:
-          - delete
-          - get
-          - list
-          - post
-          - watch
-        serviceAccountName: antrea-operator
+        - rules:
+            - nonResourceURLs:
+                - /addressgroups
+                - /agentinfo
+                - /appliedtogroups
+                - /networkpolicies
+                - /ovsflows
+                - /ovstracing
+                - /podinterfaces
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - namespaces
+                - pods
+                - serviceaccounts
+                - services
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiregistration.k8s.io
+              resources:
+                - apiservices
+              verbs:
+                - create
+                - delete
+                - get
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusteroperators/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks
+                - networks/finalizers
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - controlplane.antrea.io
+              resources:
+                - addressgroups
+                - appliedtogroups
+                - networkpolicies
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - crd.antrea.io
+              resources:
+                - antreaagentinfos
+                - antreacontrollerinfos
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+            - apiGroups:
+                - crd.antrea.io
+              resources:
+                - clusternetworkpolicies
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - crd.antrea.io
+              resources:
+                - traceflows
+                - traceflows/status
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - operator.antrea.vmware.com
+              resources:
+                - antreainstalls
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.antrea.vmware.com
+              resources:
+                - antreainstalls/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operator.openshift.io
+              resources:
+                - networks
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - system.antrea.io
+              resources:
+                - agentinfos
+                - supportbundles
+                - supportbundles/download
+              verbs:
+                - delete
+                - get
+                - list
+                - post
+                - watch
+          serviceAccountName: antrea-operator
       deployments:
-      - name: antrea-operator
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              name: antrea-operator
-          strategy: {}
-          template:
-            metadata:
-              labels:
+        - name: antrea-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 name: antrea-operator
-            spec:
-              containers:
-              - args:
-                - --enable-leader-election
-                command:
-                - antrea-operator
-                env:
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: OPERATOR_NAME
-                  value: antrea-operator
-                image: antrea/antrea-operator:v1.14.1
-                imagePullPolicy: IfNotPresent
-                name: antrea-operator
-                resources: {}
-              hostNetwork: true
-              serviceAccountName: antrea-operator
-              tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/master
-              - effect: NoSchedule
-                key: node.kubernetes.io/not-ready
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: antrea-operator
+              spec:
+                containers:
+                  - args:
+                      - --enable-leader-election
+                    command:
+                      - antrea-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: antrea-operator
+                    image: antrea/antrea-operator@sha256:15d80b1c64456226a8c0dbe41ef3f5119781b2cf556c6f08e378a1a6d333132a
+                    imagePullPolicy: IfNotPresent
+                    name: antrea-operator
+                    resources: {}
+                hostNetwork: true
+                serviceAccountName: antrea-operator
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                  - effect: NoSchedule
+                    key: node.kubernetes.io/not-ready
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps/status
-          verbs:
-          - get
-          - update
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        serviceAccountName: antrea-operator
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: antrea-operator
     strategy: deployment
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: true
-    type: SingleNamespace
-  - supported: true
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - networking
-  - security
+    - networking
+    - security
   links:
-  - name: Antrea Operator For Kubernetes
-    url: https://github.com/vmware/antrea-operator-for-kubernetes
+    - name: Antrea Operator For Kubernetes
+      url: https://github.com/vmware/antrea-operator-for-kubernetes
   maintainers:
-  - email: projectantrea-maintainers@googlegroups.com
-    name: Project Antrea Maintainers
+    - email: projectantrea-maintainers@googlegroups.com
+      name: Project Antrea Maintainers
   maturity: alpha
   minKubeVersion: 1.20.0
   provider:
     name: antrea.io
+  relatedImages:
+    - image: antrea/antrea-operator@sha256:15d80b1c64456226a8c0dbe41ef3f5119781b2cf556c6f08e378a1a6d333132a
+      name: antrea-operator
   version: 1.14.1


### PR DESCRIPTION
Plus update actions due to deprecation -  Some github actions have been deprecated and need to be updated.
    
