### PR TITLE
Default to openshift platform in Makefile

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,27 @@
+name: Generate manifests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate manifests
+        run: make manifests
+      - name: Check for any unexpected changes
+        run: |
+          diff="$(git status --porcelain)"
+          if [ ! -z "$diff" ]; then
+              >&2 echo "The generated code is not up-to-date"
+              >&2 echo "The different files are:"
+              >&2 echo "$diff"
+              >&2 echo "You can regenerate files locally with 'make manifests', and commit the changes"
+              exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,12 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to Openshift for the platform, which means for example that the Antrea
+# image will default to antrea-ubi in generate manifests. To use the operator
+# with a "vanilla" (non-Openshift) K8s cluster, you will need to explicitly set
+# ANTREA_PLATFORM=kubernetes when generating resources.
 ifndef ANTREA_PLATFORM
-	ANTREA_PLATFORM=kubernetes
+	ANTREA_PLATFORM=openshift
 endif
 
 ifndef IS_CERTIFICATION


### PR DESCRIPTION
To avoid flip-flopping between kubernetes and openshift in generated manifests. Openshift is also the main use-case at the moment for this operator.

We also add a new Github workflow to validate manifest generation for each PR.

See also #94 for a related discussion.